### PR TITLE
Fix example-kafka superUsers value

### DIFF
--- a/examples/kafka-keys-from-operator/helm/values.yaml
+++ b/examples/kafka-keys-from-operator/helm/values.yaml
@@ -1,5 +1,5 @@
 kafka:
-  superUsers: "User:CN=kafka.default,C=US,O=SPIRE"
+  superUsers: "User:CN=kafka.default,O=SPIRE,C=US;User:CN=intents-operator.intents-operator-system,O=SPIRE,C=US"
   livenessProbe:
     initialDelaySeconds: 20
   readinessProbe:
@@ -19,7 +19,7 @@ kafka:
         - kafka-tls-secret
       password: password
   authorizerClassName: kafka.security.authorizer.AclAuthorizer
-  allowEveryoneIfNoAclFound: true
+  allowEveryoneIfNoAclFound: false
   podLabels:
     app: lab-kafka
   podAnnotations:


### PR DESCRIPTION

## Description
superusers' principal should be in the exact same order as in the certificate. Therefore, C (creator) should be after O (owner)


## Link to Dev Task
https://www.notion.so/otterize/Research-document-how-to-configure-Kafka-so-the-operator-can-create-ACLs-64a687af4b204b829204fc4f4207b538