### PR TITLE
Enabled logging for SPIRE workload API, made Kafka example run until stopped

### DIFF
--- a/examples/kafka-mtls-client/src/main.go
+++ b/examples/kafka-mtls-client/src/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 )
 
 const (
@@ -65,5 +68,9 @@ func main() {
 	}
 
 	logrus.WithField("topics", topics).Info("Topics")
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	<-ctx.Done()
 
 }

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -42,7 +42,7 @@ func init() {
 
 func initSpireClient(ctx context.Context, spireServerAddr string) (spireclient.ServerClient, error) {
 	// fetch SVID & bundle through spire-agent API
-	source, err := workloadapi.NewX509Source(ctx, workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath)))
+	source, err := workloadapi.NewX509Source(ctx, workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath), workloadapi.WithLogger(logrus.StandardLogger())))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Enabled logging for SPIRE workload API, made Kafka example run until stopped

## Link to Dev Task
https://www.notion.so/otterize/Improvements-after-deploying-all-OSS-components-together-bc9780822d8141a4805ff926864e5b95
