### PR TITLE
Fix update reference for updated secrets - again

### DIFF
--- a/src/mocks/secrets/mock.go
+++ b/src/mocks/secrets/mock.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	secrets "github.com/otterize/spire-integration-operator/src/operator/secrets"
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockManager is a mock of Manager interface.
@@ -37,18 +37,17 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // EnsureTLSSecret mocks base method.
-func (m *MockManager) EnsureTLSSecret(arg0 context.Context, arg1 secrets.SecretConfig) (*v1.Secret, error) {
+func (m *MockManager) EnsureTLSSecret(arg0 context.Context, arg1 secrets.SecretConfig, arg2 v1.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureTLSSecret", arg0, arg1)
-	ret0, _ := ret[0].(*v1.Secret)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "EnsureTLSSecret", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // EnsureTLSSecret indicates an expected call of EnsureTLSSecret.
-func (mr *MockManagerMockRecorder) EnsureTLSSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) EnsureTLSSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureTLSSecret", reflect.TypeOf((*MockManager)(nil).EnsureTLSSecret), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureTLSSecret", reflect.TypeOf((*MockManager)(nil).EnsureTLSSecret), arg0, arg1, arg2)
 }
 
 // RefreshTLSSecrets mocks base method.

--- a/src/operator/controllers/pod_controller.go
+++ b/src/operator/controllers/pod_controller.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strconv"
 	"strings"
 	"time"
@@ -99,19 +98,8 @@ func (r *PodReconciler) ensurePodTLSSecret(ctx context.Context, pod *corev1.Pod,
 	certConfig := certConfigFromPod(pod)
 	log.WithFields(logrus.Fields{"secret_name": secretName, "cert_config": certConfig}).Info("ensuring TLS secret")
 	secretConfig := secrets.NewSecretConfig(entryID, entryHash, secretName, pod.Namespace, serviceName, certConfig)
-	secret, err := r.secretsManager.EnsureTLSSecret(ctx, secretConfig)
-	if err != nil {
+	if err := r.secretsManager.EnsureTLSSecret(ctx, secretConfig, pod); err != nil {
 		log.WithError(err).Error("failed creating TLS secret")
-		return err
-	}
-
-	if err := controllerutil.SetOwnerReference(pod, secret, r.Scheme()); err != nil {
-		log.WithError(err).Error("failed setting pod as owner reference")
-		return err
-	}
-
-	if err := r.Client.Update(ctx, secret); err != nil {
-		log.WithError(err).Error("failed updating pod as owner reference")
 		return err
 	}
 

--- a/src/operator/controllers/pod_controller_test.go
+++ b/src/operator/controllers/pod_controller_test.go
@@ -87,14 +87,7 @@ func (s *PodControllerSuite) TestController_Reconcile() {
 		Return(entryID, nil)
 
 	// expect TLS secret creation
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-secret",
-			Namespace: namespace,
-		},
-	}
-	s.secretsManager.EXPECT().EnsureTLSSecret(gomock.Any(), gomock.Any()).Return(secret, nil)
-	s.client.EXPECT().Update(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(nil)
+	s.secretsManager.EXPECT().EnsureTLSSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: podname}}
 	result, err := s.podReconciler.Reconcile(context.Background(), request)

--- a/src/operator/secrets/manager_test.go
+++ b/src/operator/secrets/manager_test.go
@@ -125,9 +125,8 @@ func (s *ManagerSuite) TestManager_EnsureTLSSecret_NoExistingSecret() {
 
 	secretConf := NewSecretConfig(entryId, "", secretName, namespace, serviceName, certConfig)
 
-	secret, err := s.manager.EnsureTLSSecret(context.Background(), secretConf)
+	err = s.manager.EnsureTLSSecret(context.Background(), secretConf, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(secret)
 }
 
 func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_NeedsRefresh() {
@@ -179,9 +178,8 @@ func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_NeedsRefr
 
 	certConfig := CertConfig{CertType: StrToCertType("pem"), PemConfig: NewPemConfig("", "", "")}
 	secretConf := NewSecretConfig(entryId, "", secretName, namespace, serviceName, certConfig)
-	secret, err := s.manager.EnsureTLSSecret(context.Background(), secretConf)
+	err = s.manager.EnsureTLSSecret(context.Background(), secretConf, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(secret)
 }
 
 func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_NoRefreshNeeded() {
@@ -213,12 +211,29 @@ func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_NoRefresh
 		}
 	})
 
+	testData, err := testdata.LoadTestData()
+	s.Require().NoError(err)
+
+	s.mockTLSStores(entryId, testData)
+
+	s.client.EXPECT().Update(
+		gomock.Any(),
+		&TLSSecretMatcher{
+			namespace: namespace,
+			name:      secretName,
+			tlsData: map[string][]byte{
+				"bundle.pem": testData.BundlePEM,
+				"key.pem":    testData.KeyPEM,
+				"svid.pem":   testData.SVIDPEM,
+			},
+		},
+	).Return(nil)
+
 	certConfig := CertConfig{CertType: StrToCertType("pem"), PemConfig: NewPemConfig("", "", "")}
 	secretConf := NewSecretConfig(entryId, "", secretName, namespace, serviceName, certConfig)
 
-	secret, err := s.manager.EnsureTLSSecret(context.Background(), secretConf)
+	err = s.manager.EnsureTLSSecret(context.Background(), secretConf, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(secret)
 }
 
 func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_UpdateNeeded_NewSecrets() {
@@ -275,9 +290,8 @@ func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_UpdateNee
 
 	secretConf := NewSecretConfig(entryId, "", secretName, namespace, serviceName, certConfig)
 
-	secret, err := s.manager.EnsureTLSSecret(context.Background(), secretConf)
+	err = s.manager.EnsureTLSSecret(context.Background(), secretConf, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(secret)
 }
 
 func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_UpdateNeeded_EntryHashChanged() {
@@ -334,9 +348,8 @@ func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_UpdateNee
 
 	secretConf := NewSecretConfig(entryId, newEntryHash, secretName, namespace, serviceName, certConfig)
 
-	secret, err := s.manager.EnsureTLSSecret(context.Background(), secretConf)
+	err = s.manager.EnsureTLSSecret(context.Background(), secretConf, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(secret)
 }
 
 func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_UpdateNeeded_CertTypeChanged() {
@@ -393,9 +406,8 @@ func (s *ManagerSuite) TestManager_EnsureTLSSecret_ExistingSecretFound_UpdateNee
 
 	secretConf := NewSecretConfig(entryId, "", secretName, namespace, serviceName, certConfig)
 
-	secret, err := s.manager.EnsureTLSSecret(context.Background(), secretConf)
+	err = s.manager.EnsureTLSSecret(context.Background(), secretConf, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(secret)
 }
 
 func (s *ManagerSuite) TestManager_RefreshTLSSecrets_RefreshNeeded() {


### PR DESCRIPTION
## Description
This time the issue was that when an existing secret was updated, we updated the new secret obj rather than the existing one, leading to some state lost in the update. 
See also https://github.com/otterize/spire-integration-operator/pull/33

## Link to Dev Task
https://www.notion.so/otterize/Spire-integration-operator-does-not-register-pod-as-secret-owner-if-the-secret-already-exists-and-do-b472f78024df43a8902710dd7cb83b6c
