### PR TITLE
Don't update secret data unless necessary

### DIFF
--- a/src/operator/secrets/manager.go
+++ b/src/operator/secrets/manager.go
@@ -266,9 +266,13 @@ func (m *managerImpl) EnsureTLSSecret(ctx context.Context, config SecretConfig, 
 		}
 	}
 
-	if err := m.updateTLSSecretConfig(ctx, config, secret); err != nil {
-		log.WithError(err).Error("failed updating TLS secret config")
-		return err
+	if !isExistingSecret ||
+		m.isRefreshNeeded(secret) ||
+		m.isUpdateNeeded(SecretConfigFromExistingSecret(secret), config) {
+		if err := m.updateTLSSecretConfig(ctx, config, secret); err != nil {
+			log.WithError(err).Error("failed updating TLS secret config")
+			return err
+		}
 	}
 
 	if owner != nil {


### PR DESCRIPTION
## Description
Follow up on https://github.com/otterize/spire-integration-operator/pull/36 - update secret content only when needed.


## Link to Dev Task
https://www.notion.so/otterize/Spire-integration-operator-does-not-register-pod-as-secret-owner-if-the-secret-already-exists-and-do-b472f78024df43a8902710dd7cb83b6c
