### PR TITLE
Fix default API address

### DIFF
--- a/src/operator/controllers/otterizeclient/config.go
+++ b/src/operator/controllers/otterizeclient/config.go
@@ -9,7 +9,7 @@ const (
 	ApiClientIdKey                 = "client-id"
 	ApiClientSecretKey             = "client-secret"
 	OtterizeAPIAddressKey          = "api-address"
-	OtterizeAPIAddressDefault      = "https://app.otterize.com"
+	OtterizeAPIAddressDefault      = "https://app.otterize.com/api"
 	EnvPrefix                      = "OTTERIZE"
 	ComponentReportIntervalKey     = "component-report-interval"
 	ComponentReportIntervalDefault = 60


### PR DESCRIPTION
The default config value for API address was missing the `/api` suffix - now corrected