### PR TITLE
Fix bug: Sending nil when no namespaced pod owners found

### DIFF
--- a/src/operator/controllers/otterizeclient/client.go
+++ b/src/operator/controllers/otterizeclient/client.go
@@ -60,11 +60,6 @@ func (c *CloudClient) CleanupOrphanK8SPodEntries(ctx context.Context, _ string, 
 			namespacedPodOwners = append(namespacedPodOwners, otterizegraphql.NamespacedPodOwner{Namespace: namespace, Name: podOwner})
 		}
 	}
-
-	if len(namespacedPodOwners) == 0 {
-		return nil
-	}
-
 	res, err := otterizegraphql.ReportActiveCertificateRequesters(ctx, c.graphqlClient, namespacedPodOwners)
 	if err != nil {
 		return fmt.Errorf("failed removing orphan entries: %w", err)


### PR DESCRIPTION
### Description

When the operator doesn't find pod owners for `ReportActiveCertificateRequesters` it sends a nil value. This PR initialize the slice to non-nil value and also skip the API call since the backend has nothing to do if the list is empty.
