### PR TITLE
Add version variable to Github build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            "VERSION=${{ github.run_id }}"
+
 
   tag-latest:
     name: Tag latest


### PR DESCRIPTION
### Description

Telemetry events should be sent with application version, this PR add using version on build action as Github run id like all other repos do
