### PR TITLE
Configure logger to use JSON format

### DIFF
--- a/src/operator/controllers/aws_iam/serviceaccount/serviceaccount_controller.go
+++ b/src/operator/controllers/aws_iam/serviceaccount/serviceaccount_controller.go
@@ -137,10 +137,10 @@ func (r *ServiceAccountReconciler) reconcileAWSRole(ctx context.Context, service
 
 		if found {
 			if generatedRoleARN != roleARN {
-				logger.WithField("arn", role.Arn).Debug("ServiceAccount AWS role exists, but annotation is misconfigured, should be updated")
+				logger.WithField("arn", *role.Arn).Debug("ServiceAccount AWS role exists, but annotation is misconfigured, should be updated")
 				return true, role, nil
 			}
-			logger.WithField("arn", role.Arn).Debug("ServiceAccount has matching AWS role")
+			logger.WithField("arn", *role.Arn).Debug("ServiceAccount has matching AWS role")
 			return false, role, nil
 		}
 	}
@@ -150,7 +150,7 @@ func (r *ServiceAccountReconciler) reconcileAWSRole(ctx context.Context, service
 		return true, nil, fmt.Errorf("failed creating AWS role for service account: %w", err)
 	}
 
-	logger.WithField("arn", role.Arn).Info("created AWS role for ServiceAccount")
+	logger.WithField("arn", *role.Arn).Info("created AWS role for ServiceAccount")
 	return true, role, nil
 }
 

--- a/src/operator/controllers/aws_iam/webhooks/pod_webhook.go
+++ b/src/operator/controllers/aws_iam/webhooks/pod_webhook.go
@@ -117,6 +117,7 @@ func (a *ServiceAccountAnnotatingPodWebhook) Handle(ctx context.Context, req adm
 
 	pod, patched, successMsg, err := a.handleWithRetriesOnConflictOrNotFound(ctx, pod, req.DryRun != nil && *req.DryRun)
 	if err != nil {
+		logrus.WithError(err).Errorf("failed to annotate service account, but pod admitted to ensure success")
 		return admission.Allowed("pod admitted, but failed to annotate service account, see warnings").WithWarnings(err.Error())
 	}
 

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -57,6 +57,8 @@ import (
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"strings"
+	"time"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -165,6 +167,9 @@ func main() {
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+	logrus.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339,
+	})
 
 	ctrl.SetLogger(logrusr.New(logrus.StandardLogger()))
 


### PR DESCRIPTION
### Description

Before this PR, the credentials operator logged in key=value format, as the logger was misconfigured. This PR causes it to log in JSON format, like the intents operator and network mapper.