### PR TITLE
PostgreSQL: Username and password no longer erroneously require certificate provider = cloud to be selected

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -205,6 +205,7 @@ func main() {
 
 	if clientInitializedWithCredentials {
 		otterizeclient.PeriodicallyReportConnectionToCloud(otterizeCloudClient)
+		userAndPassAcquirer = otterizeCloudClient
 	}
 
 	if certProvider == CertProviderCloud {
@@ -212,7 +213,6 @@ func main() {
 			logrus.WithError(err).Panic("using cloud, but cloud credentials not specified")
 		}
 		workloadRegistry = otterizeCloudClient
-		userAndPassAcquirer = otterizeCloudClient
 		otterizeCertManager := otterizecertgen.NewOtterizeCertificateGenerator(otterizeCloudClient)
 		secretsManager = secrets.NewDirectSecretsManager(mgr.GetClient(), serviceIdResolver, eventRecorder, otterizeCertManager)
 	} else if certProvider == CertProviderSPIRE {


### PR DESCRIPTION
### Description

Prior to this PR, you had to set certificateProvider=otterize-cloud in order to use the username and password capabilities of the credentials operator. But username and passwords are not certificates, so this PR makes it so you just need to enable cloud instead.