### PR TITLE
Add support for marking AWS roles and policies as unused instead of deleting them

### DIFF
--- a/src/operator/controllers/aws_iam/webhooks/pod_webhook.go
+++ b/src/operator/controllers/aws_iam/webhooks/pod_webhook.go
@@ -74,6 +74,12 @@ func (a *ServiceAccountAnnotatingPodWebhook) handleOnce(ctx context.Context, pod
 	// we don't actually create the role here, so that the webhook returns quickly - a ServiceAccount reconciler takes care of it for us.
 	updatedServiceAccount.Annotations[metadata.ServiceAccountAWSRoleARNAnnotation] = roleArn
 	updatedServiceAccount.Labels[metadata.OtterizeServiceAccountLabel] = metadata.OtterizeServiceAccountHasPodsValue
+
+	_, dontDeleteRole := pod.Labels[metadata.OtterizeDontDeleteAWSRoleLabel]
+	if dontDeleteRole {
+		updatedServiceAccount.Labels[metadata.OtterizeDontDeleteAWSRoleLabel] = "true"
+	}
+
 	if !dryRun {
 		err = a.client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
 		if err != nil {

--- a/src/operator/controllers/metadata/labels.go
+++ b/src/operator/controllers/metadata/labels.go
@@ -17,4 +17,8 @@ const (
 	OtterizeServiceAccountHasNoPodsValue = "no-pods"
 	// CreateAWSRoleLabel by using this annotation a pod marks that the operator should create an AWS IAM role for its service account
 	CreateAWSRoleLabel = "credentials-operator.otterize.com/create-aws-role"
+
+	// OtterizeDontDeleteAWSRoleLabel is used to mark workloads that should not have their corresponding roles deleted,
+	// but should be tagged as unused instead
+	OtterizeDontDeleteAWSRoleLabel = "credentials-operator.otterize.com/dont-delete-aws-role"
 )

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -146,6 +146,7 @@ func main() {
 	var secretsManager tls_pod.SecretsManager
 	var workloadRegistry tls_pod.WorkloadRegistry
 	var enableAWSServiceAccountManagement bool
+	var markAwsRolesAndPoliciesAsUnusedInsteadOfDelete bool
 	var debug bool
 	var userAndPassAcquirer poduserpassword.CloudUserAndPasswordAcquirer
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":7071", "The address the metric endpoint binds to.")
@@ -157,6 +158,7 @@ func main() {
 	flag.BoolVar(&certManagerUseClusterIssuer, "cert-manager-use-cluster-issuer", false, "Use ClusterIssuer instead of a (namespace bound) Issuer")
 	flag.BoolVar(&useCertManagerApprover, "cert-manager-approve-requests", false, "Make credentials-operator approve its own CertificateRequests")
 	flag.BoolVar(&enableAWSServiceAccountManagement, "enable-aws-serviceaccount-management", false, "Create and bind ServiceAccounts to AWS IAM roles")
+	flag.BoolVar(&markAwsRolesAndPoliciesAsUnusedInsteadOfDelete, "mark-aws-roles-as-unused-instead-of-delete", false, "Mark AWS roles and policies as unused instead of deleting them")
 	flag.BoolVar(&debug, "debug", false, "Enable debug logging")
 
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -246,7 +248,7 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Panic("failed to initialize AWS agent")
 		}
-		serviceAccountReconciler := serviceaccount.NewServiceAccountReconciler(client, awsAgent)
+		serviceAccountReconciler := serviceaccount.NewServiceAccountReconciler(client, awsAgent, markAwsRolesAndPoliciesAsUnusedInsteadOfDelete)
 		if err = serviceAccountReconciler.SetupWithManager(mgr); err != nil {
 			logrus.WithField("controller", "ServiceAccount").WithError(err).Panic("unable to create controller")
 		}


### PR DESCRIPTION


### Description

Add support for marking AWS roles and policies as unused instead of deleting them

### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- StackOverflow post
- Related pull requests/issues from other repos

If there are no references, simply delete this section.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
