### PR TITLE
Fix issue running AWS webhooks alongside GCP and Azure simultaneously

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -295,16 +295,17 @@ func main() {
 		if err = reconciler.SetupWithManager(mgr); err != nil {
 			logrus.WithField("controller", "MutatingWebhookConfigs").WithError(err).Panic("unable to create controller")
 		}
-
-		if viper.GetBool(operatorconfig.EnableAWSServiceAccountManagementKey) {
-			webhookHandler = sa_pod_webhook_aws.NewServiceAccountAnnotatingPodWebhook(mgr, awsAgent)
-		}
-
-		if viper.GetBool(operatorconfig.EnableAWSRolesAnywhereKey) {
-			webhookHandler = spiffe_rolesanywhere_pod_webhook.NewSPIFFEAWSRolePodWebhook(mgr, awsAgent, viper.GetString(operatorconfig.AWSRolesAnywhereTrustAnchorARNKey))
-		}
-
 		mgr.GetWebhookServer().Register("/mutate-v1-pod", &webhook.Admission{Handler: webhookHandler})
+
+		if viper.GetBool(operatorconfig.EnableAWSServiceAccountManagementKey) || viper.GetBool(operatorconfig.EnableAWSRolesAnywhereKey) {
+			var awsWebhookHandler admission.Handler = sa_pod_webhook_aws.NewServiceAccountAnnotatingPodWebhook(mgr, awsAgent)
+
+			if viper.GetBool(operatorconfig.EnableAWSRolesAnywhereKey) {
+				awsWebhookHandler = spiffe_rolesanywhere_pod_webhook.NewSPIFFEAWSRolePodWebhook(mgr, awsAgent, viper.GetString(operatorconfig.AWSRolesAnywhereTrustAnchorARNKey))
+			}
+
+			mgr.GetWebhookServer().Register("/mutate-aws-v1-pod", &webhook.Admission{Handler: awsWebhookHandler})
+		}
 
 	}
 


### PR DESCRIPTION
Before this PR, it was only possible to use one of the AWS/GCP/Azure integrations on the same cluster. Trying to use both AWS and one of the other two would replace the webhook handler and as a result, would not work.

Accompanies https://github.com/otterize/helm-charts/pull/192