### PR TITLE
Fixed bugs where operator tried reading secrets in deleting namespaces and pods/owners were missing for short-period jobs in redudant reconciles that were queued

### DIFF
--- a/src/operator/controllers/intents/database_user_reconciler.go
+++ b/src/operator/controllers/intents/database_user_reconciler.go
@@ -37,15 +37,15 @@ const (
 	OtterizeIntentsClientIndexNameField     = "spec.service.name"
 )
 
-type Reconciler struct {
+type DatabaseUserReconciler struct {
 	client            client.Client
 	scheme            *runtime.Scheme
 	recorder          record.EventRecorder
 	serviceIdResolver *serviceidresolver.Resolver
 }
 
-func NewReconciler(client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder, serviceIdResolver *serviceidresolver.Resolver) *Reconciler {
-	return &Reconciler{
+func NewReconciler(client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder, serviceIdResolver *serviceidresolver.Resolver) *DatabaseUserReconciler {
+	return &DatabaseUserReconciler{
 		client:            client,
 		scheme:            scheme,
 		serviceIdResolver: serviceIdResolver,
@@ -53,7 +53,7 @@ func NewReconciler(client client.Client, scheme *runtime.Scheme, eventRecorder r
 	}
 }
 
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *DatabaseUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
 		For(&otterizev1alpha3.ClientIntents{}).
@@ -62,7 +62,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *Reconciler) mapPodToClientIntents(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *DatabaseUserReconciler) mapPodToClientIntents(ctx context.Context, obj client.Object) []reconcile.Request {
 	requests := make([]reconcile.Request, 0)
 	pod := obj.(*v1.Pod)
 	if !pod.DeletionTimestamp.IsZero() || isPodStatusDone(pod) {
@@ -102,7 +102,7 @@ func isPodStatusDone(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed
 }
 
-func (r *Reconciler) mapPGServerConfToClientIntents(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *DatabaseUserReconciler) mapPGServerConfToClientIntents(ctx context.Context, obj client.Object) []reconcile.Request {
 	pgServerConf := obj.(*otterizev1alpha3.PostgreSQLServerConfig)
 	logrus.Infof("Enqueueing client intents for PostgreSQLServerConfig change %s", pgServerConf.Name)
 
@@ -130,7 +130,9 @@ func (r *Reconciler) mapPGServerConfToClientIntents(ctx context.Context, obj cli
 	return requests
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *DatabaseUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// The credentials operator doesn't have any cleanup to do, like removing permissions or deleting users
+	// If a namespace is being deleted, we can stop reconciliation and let the intents operator handle everything else
 	terminating, err := r.isNamespaceTerminating(ctx, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err)
@@ -182,7 +184,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) createPostgresUserForWorkload(
+func (r *DatabaseUserReconciler) createPostgresUserForWorkload(
 	ctx context.Context,
 	pgConfigurator *postgres.PostgresConfigurator,
 	pgUsername string,
@@ -201,7 +203,7 @@ func (r *Reconciler) createPostgresUserForWorkload(
 	return nil
 }
 
-func (r *Reconciler) getPostgresUserForWorkload(ctx context.Context, clientName, namespace string) (string, error) {
+func (r *DatabaseUserReconciler) getPostgresUserForWorkload(ctx context.Context, clientName, namespace string) (string, error) {
 	clusterUID, err := clusterutils.GetClusterUID(ctx)
 	if err != nil {
 		return "", errors.Wrap(err)
@@ -210,7 +212,7 @@ func (r *Reconciler) getPostgresUserForWorkload(ctx context.Context, clientName,
 	return clusterutils.KubernetesToPostgresName(username), nil
 }
 
-func (r *Reconciler) fetchWorkloadPassword(ctx context.Context, clientIntents otterizev1alpha3.ClientIntents) (string, error) {
+func (r *DatabaseUserReconciler) fetchWorkloadPassword(ctx context.Context, clientIntents otterizev1alpha3.ClientIntents) (string, error) {
 	pod, err := r.serviceIdResolver.ResolveClientIntentToPod(ctx, clientIntents)
 	if err != nil {
 		return "", errors.Wrap(err)
@@ -231,7 +233,7 @@ func (r *Reconciler) fetchWorkloadPassword(ctx context.Context, clientIntents ot
 	return string(secret.Data["password"]), nil
 }
 
-func (r *Reconciler) InitIntentsClientIndices(mgr ctrl.Manager) error {
+func (r *DatabaseUserReconciler) InitIntentsClientIndices(mgr ctrl.Manager) error {
 	err := mgr.GetCache().IndexField(
 		context.Background(),
 		&otterizev1alpha3.ClientIntents{}, OtterizeIntentsClientIndexNameField,
@@ -246,7 +248,7 @@ func (r *Reconciler) InitIntentsClientIndices(mgr ctrl.Manager) error {
 	return nil
 }
 
-func (r *Reconciler) InitIntentsDatabaseServerIndices(mgr ctrl.Manager) error {
+func (r *DatabaseUserReconciler) InitIntentsDatabaseServerIndices(mgr ctrl.Manager) error {
 	err := mgr.GetCache().IndexField(
 		context.Background(),
 		&otterizev1alpha3.ClientIntents{},
@@ -271,7 +273,7 @@ func (r *Reconciler) InitIntentsDatabaseServerIndices(mgr ctrl.Manager) error {
 	return nil
 }
 
-func (r *Reconciler) handleDBUserCreation(
+func (r *DatabaseUserReconciler) handleDBUserCreation(
 	ctx context.Context,
 	intents otterizev1alpha3.ClientIntents,
 	pgConfigurator *postgres.PostgresConfigurator,
@@ -311,10 +313,7 @@ func (r *Reconciler) handleDBUserCreation(
 	return nil
 }
 
-func (r *Reconciler) isNamespaceTerminating(ctx context.Context, namespace string) (bool, error) {
-	// The credentials operator doesn't have any cleanup to do, like removing permissions or deleting users
-	// If a namespace is being deleted, we can stop reconciliation and let the intents operator handle everything else
-
+func (r *DatabaseUserReconciler) isNamespaceTerminating(ctx context.Context, namespace string) (bool, error) {
 	ns := v1.Namespace{}
 	if err := r.client.Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
 		return false, errors.Wrap(err)

--- a/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
+++ b/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
@@ -150,11 +150,11 @@ func buildUserAndPasswordCredentialsSecret(name, namespace, pgUsername, password
 func createServicePassword() (string, error) {
 	password, err := nanoid.Generate(DefaultCredentialsAlphabet, DefaultCredentialsLen)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err)
 	}
 	salt, err := nanoid.Generate(DefaultCredentialsAlphabet, 8)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err)
 	}
 
 	dk := pbkdf2.Key([]byte(password), []byte(salt), 2048, 16, sha256.New)


### PR DESCRIPTION
### Description
Fixed bugs where operator tried reading secrets in deleting namespaces and pods/owners were missing for short-period jobs in redudant reconciles that were queued