### PR TITLE
Support reading database ServerConfig credentials from k8s secrets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,10 +66,11 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@f8e9a06ffaecc3d362196ef410e7e4f0bb8f54e2
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@09e985e6807f08c845235fddf0494ce1a87a7453
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:
+      github_ref: 09e985e6807f08c845235fddf0494ce1a87a7453
       gcr-registry: ${{ needs.build.outputs.registry }}
       credentials-operator-tag: ${{ github.sha }}
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@c867344a7eb64a42667765e87cf96b0d4b97d685
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@3b2a612385d4765a6a6b27b6ecb262980fe19a3e
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,11 +66,11 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@09e985e6807f08c845235fddf0494ce1a87a7453
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@949a04bfc6a23a936ec23b5ce0dbf62b33471f3e
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:
-      github_ref: 09e985e6807f08c845235fddf0494ce1a87a7453
+      github_ref: 949a04bfc6a23a936ec23b5ce0dbf62b33471f3e
       gcr-registry: ${{ needs.build.outputs.registry }}
       credentials-operator-tag: ${{ github.sha }}
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@f59187d67f24fb99adbe218f1111d1168b1696e8
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@c867344a7eb64a42667765e87cf96b0d4b97d685
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,13 @@ jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.registry.outputs.registry }} # workaround since env is not available outside of steps, i.e. in calling external workflows like we later do in e2e-test
+
     steps:
+      - id: registry
+        run: echo "registry=${{ env.REGISTRY }}" >> "$GITHUB_OUTPUT"
+
       - name: Check out the code
         uses: actions/checkout@v2
         with:
@@ -59,6 +65,15 @@ jobs:
           build-args: |
             "VERSION=0.0.${{ github.run_id }}"
 
+  helm-e2e-test:
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@b5d416e5977f52f7cd605f608b3666e423c53004
+    name: Trigger e2e tests from helm charts repo
+    secrets: inherit
+    with:
+      gcr-registry: ${{ needs.build.outputs.registry }}
+      credentials-operator-tag: ${{ github.sha }}
+    needs:
+      - build
 
   tag-latest:
     name: Tag latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@b5d416e5977f52f7cd605f608b3666e423c53004
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@5335a1de6ab7167fb8eedcb965b7e35298d9a007
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@3b2a612385d4765a6a6b27b6ecb262980fe19a3e
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@f8e9a06ffaecc3d362196ef410e7e4f0bb8f54e2
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@5335a1de6ab7167fb8eedcb965b7e35298d9a007
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@f59187d67f24fb99adbe218f1111d1168b1696e8
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,11 +66,10 @@ jobs:
             "VERSION=0.0.${{ github.run_id }}"
 
   helm-e2e-test:
-    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@949a04bfc6a23a936ec23b5ce0dbf62b33471f3e
+    uses: otterize/helm-charts/.github/workflows/e2e-test.yaml@main
     name: Trigger e2e tests from helm charts repo
     secrets: inherit
     with:
-      github_ref: 949a04bfc6a23a936ec23b5ce0dbf62b33471f3e
       gcr-registry: ${{ needs.build.outputs.registry }}
       credentials-operator-tag: ${{ github.sha }}
     needs:

--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94 // indirect
+	github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6 // indirect
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect

--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6 // indirect
+	github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78 // indirect
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect

--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78 // indirect
+	github.com/otterize/intents-operator/src v0.0.0-20240623153715-3086fe975a9f // indirect
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect

--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/otterize/intents-operator/src v0.0.0-20240521104220-ba00b7c59637 // indirect
+	github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94 // indirect
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect

--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/otterize/intents-operator/src v0.0.0-20240623153715-3086fe975a9f // indirect
+	github.com/otterize/intents-operator/src v0.0.0-20240623163818-27d9ebb4f4eb // indirect
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -444,6 +444,8 @@ github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78 h1:Y
 github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/intents-operator/src v0.0.0-20240623153715-3086fe975a9f h1:60VQ/nyov3Pqq6NCBPrf4VjJzpsfjSsC6L7Zw9qot8Q=
 github.com/otterize/intents-operator/src v0.0.0-20240623153715-3086fe975a9f/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
+github.com/otterize/intents-operator/src v0.0.0-20240623163818-27d9ebb4f4eb h1:aGBbne9jtKspb0fgvQHpIgN5t9mErIMXBNp1Y7XEx8g=
+github.com/otterize/intents-operator/src v0.0.0-20240623163818-27d9ebb4f4eb/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -440,6 +440,8 @@ github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94 h1:W
 github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6 h1:M5ZLoxXTpm5u3MV3c0M5WOsIB03ESLZiHDjTl5y2xYg=
 github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
+github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78 h1:YDVGIeLdoLqSZfF9eRJyBP0GRK7UsIoWWCUQcX9qW5M=
+github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -436,6 +436,8 @@ github.com/otterize/intents-operator/src v0.0.0-20240521053840-36662b8fd8fa h1:R
 github.com/otterize/intents-operator/src v0.0.0-20240521053840-36662b8fd8fa/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/intents-operator/src v0.0.0-20240521104220-ba00b7c59637 h1:fhtXDgHYymOrHaAdaBg7kTs8D53u35nmGXYLiDhVjtU=
 github.com/otterize/intents-operator/src v0.0.0-20240521104220-ba00b7c59637/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
+github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94 h1:WdA+1YWuYc75WGuhQ2XGdZGD/PQQq/Qoml3CJYYs1xE=
+github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -438,6 +438,8 @@ github.com/otterize/intents-operator/src v0.0.0-20240521104220-ba00b7c59637 h1:f
 github.com/otterize/intents-operator/src v0.0.0-20240521104220-ba00b7c59637/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94 h1:WdA+1YWuYc75WGuhQ2XGdZGD/PQQq/Qoml3CJYYs1xE=
 github.com/otterize/intents-operator/src v0.0.0-20240618094714-4c1711705a94/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
+github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6 h1:M5ZLoxXTpm5u3MV3c0M5WOsIB03ESLZiHDjTl5y2xYg=
+github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -442,6 +442,8 @@ github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6 h1:M
 github.com/otterize/intents-operator/src v0.0.0-20240623111815-b96773bfb6c6/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78 h1:YDVGIeLdoLqSZfF9eRJyBP0GRK7UsIoWWCUQcX9qW5M=
 github.com/otterize/intents-operator/src v0.0.0-20240623113422-6820f7294c78/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
+github.com/otterize/intents-operator/src v0.0.0-20240623153715-3086fe975a9f h1:60VQ/nyov3Pqq6NCBPrf4VjJzpsfjSsC6L7Zw9qot8Q=
+github.com/otterize/intents-operator/src v0.0.0-20240623153715-3086fe975a9f/go.mod h1:7vDL6/NAo7AobUGqDGU/277xGyb0KTRQoqRjoouhh44=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=


### PR DESCRIPTION
### Description
- Support reading database credentials for PostgreSQL & MySQL, from a k8s secret, referenced by their database ServerConfig. 
- Implement backwards compatibility with existing database ServerConfigs, with fallback to plaintext username & password specified in the ServerConfig. 
- Call E2E tests workflow from https://github.com/otterize/helm-charts on build workflow

### References
https://github.com/otterize/helm-charts/pull/218
https://github.com/otterize/intents-operator/pull/440
https://github.com/otterize/credentials-operator/pull/143
https://github.com/otterize/docs/pull/243

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
