### PR TITLE
Fix error reporting missing stack trace due to using fmt.Errorf rather than errors.Errorf

### DIFF
--- a/src/operator/controllers/certificates/jks/jks.go
+++ b/src/operator/controllers/certificates/jks/jks.go
@@ -65,7 +65,7 @@ func PemToKeyStore(certificatesChainPEM [][]byte, keyPem []byte, password string
 			return keystore.KeyStore{}, errors.Wrap(err)
 		}
 	default:
-		return keystore.KeyStore{}, fmt.Errorf("unsupprted block type for pricate key: %s", block.Type)
+		return keystore.KeyStore{}, errors.Errorf("unsupprted block type for private key: %s", block.Type)
 
 	}
 

--- a/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
+++ b/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
@@ -2,7 +2,6 @@ package awscredentialsagent
 
 import (
 	"context"
-	"fmt"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	rolesanywhereTypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
 	"github.com/otterize/credentials-operator/src/shared/apiutils"
@@ -182,7 +181,7 @@ func (a *Agent) OnServiceAccountUpdate(ctx context.Context, serviceAccount *core
 	role, err := a.agent.CreateOtterizeIAMRole(ctx, serviceAccount.Namespace, serviceAccount.Name, a.shouldUseSoftDeleteStrategy(serviceAccount))
 
 	if err != nil {
-		return false, false, fmt.Errorf("failed creating AWS role for service account: %w", err)
+		return false, false, errors.Errorf("failed creating AWS role for service account: %w", err)
 	}
 	logger.WithField("arn", *role.Arn).Info("created AWS role for ServiceAccount")
 
@@ -222,13 +221,13 @@ func (a *Agent) OnServiceAccountTermination(ctx context.Context, serviceAccount 
 
 	err := a.agent.DeleteOtterizeIAMRole(ctx, serviceAccount.Namespace, serviceAccount.Name)
 	if err != nil {
-		return fmt.Errorf("failed to remove service account: %w", err)
+		return errors.Errorf("failed to remove service account: %w", err)
 	}
 
 	if a.agent.RolesAnywhereEnabled {
 		deleted, err := a.agent.DeleteRolesAnywhereProfileForServiceAccount(ctx, serviceAccount.Namespace, serviceAccount.Name)
 		if err != nil {
-			return fmt.Errorf("failed to remove rolesanywhere profile for service account: %w", err)
+			return errors.Errorf("failed to remove rolesanywhere profile for service account: %w", err)
 		}
 
 		if !deleted {

--- a/src/operator/controllers/iam/pods/pods_controller.go
+++ b/src/operator/controllers/iam/pods/pods_controller.go
@@ -2,7 +2,6 @@ package pods
 
 import (
 	"context"
-	"fmt"
 	"github.com/otterize/credentials-operator/src/controllers/iam/iamcredentialsagents"
 	"github.com/otterize/credentials-operator/src/controllers/metadata"
 	"github.com/otterize/credentials-operator/src/shared/apiutils"
@@ -72,7 +71,7 @@ func (r *PodReconciler) handlePodUpdate(ctx context.Context, pod corev1.Pod) (ct
 	var serviceAccount corev1.ServiceAccount
 	err := r.Get(ctx, types.NamespacedName{Name: pod.Spec.ServiceAccountName, Namespace: pod.Namespace}, &serviceAccount)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get service account: %w", err)
+		return ctrl.Result{}, errors.Errorf("failed to get service account: %w", err)
 	}
 
 	updatedServiceAccount := serviceAccount.DeepCopy()
@@ -80,7 +79,7 @@ func (r *PodReconciler) handlePodUpdate(ctx context.Context, pod corev1.Pod) (ct
 
 	updated, requeue, err := r.agent.OnPodUpdate(ctx, updatedPod, updatedServiceAccount)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile pod: %w", err)
+		return ctrl.Result{}, errors.Errorf("failed to reconcile pod: %w", err)
 	}
 	if requeue {
 		return ctrl.Result{Requeue: true}, nil

--- a/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
+++ b/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
@@ -2,7 +2,6 @@ package serviceaccounts
 
 import (
 	"context"
-	"fmt"
 	"github.com/otterize/credentials-operator/src/controllers/iam/iamcredentialsagents"
 	"github.com/otterize/credentials-operator/src/controllers/metadata"
 	"github.com/otterize/intents-operator/src/shared/errors"
@@ -68,7 +67,7 @@ func (r *ServiceAccountReconciler) handleServiceAccountUpdate(ctx context.Contex
 	updatedServiceAccount := serviceAccount.DeepCopy()
 	updated, requeue, err := r.agent.OnServiceAccountUpdate(ctx, updatedServiceAccount)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile service account: %w", err)
+		return ctrl.Result{}, errors.Errorf("failed to reconcile service account: %w", err)
 	}
 	if requeue {
 		return ctrl.Result{Requeue: true}, nil
@@ -95,7 +94,7 @@ func (r *ServiceAccountReconciler) handleServiceAccountCleanup(ctx context.Conte
 	}
 
 	if err := r.agent.OnServiceAccountTermination(ctx, &serviceAccount); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to remove service account: %w", err)
+		return ctrl.Result{}, errors.Errorf("failed to remove service account: %w", err)
 	}
 
 	// remove finalizer to unblock deletion

--- a/src/operator/controllers/iam/webhooks/pod_webhook.go
+++ b/src/operator/controllers/iam/webhooks/pod_webhook.go
@@ -3,7 +3,6 @@ package sa_pod_webhook
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/otterize/credentials-operator/src/controllers/iam/iamcredentialsagents"
 	"github.com/otterize/credentials-operator/src/controllers/metadata"
 	"github.com/otterize/credentials-operator/src/shared/apiutils"
@@ -60,19 +59,19 @@ func (w *ServiceAccountAnnotatingPodWebhook) handleOnce(ctx context.Context, pod
 		Name:      pod.Spec.ServiceAccountName,
 	}, &serviceAccount)
 	if err != nil {
-		return corev1.Pod{}, false, "", fmt.Errorf("could not get service account: %w", err)
+		return corev1.Pod{}, false, "", errors.Errorf("could not get service account: %w", err)
 	}
 
 	updatedServiceAccount := serviceAccount.DeepCopy()
 	if err := w.agent.OnPodAdmission(ctx, &pod, updatedServiceAccount, dryRun); err != nil {
-		return corev1.Pod{}, false, "", fmt.Errorf("failed to handle pod admission: %w", err)
+		return corev1.Pod{}, false, "", errors.Errorf("failed to handle pod admission: %w", err)
 	}
 
 	if !dryRun {
 		apiutils.AddLabel(updatedServiceAccount, w.agent.ServiceAccountLabel(), metadata.OtterizeServiceAccountHasPodsValue)
 		err = w.client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
 		if err != nil {
-			return corev1.Pod{}, false, "", fmt.Errorf("could not patch service account: %w", err)
+			return corev1.Pod{}, false, "", errors.Errorf("could not patch service account: %w", err)
 		}
 	}
 

--- a/src/operator/controllers/otterizeclient/client.go
+++ b/src/operator/controllers/otterizeclient/client.go
@@ -2,7 +2,6 @@ package otterizeclient
 
 import (
 	"context"
-	"fmt"
 	"github.com/Khan/genqlient/graphql"
 	"github.com/amit7itz/goset"
 	"github.com/otterize/credentials-operator/src/controllers/otterizeclient/otterizegraphql"
@@ -67,10 +66,10 @@ func (c *CloudClient) CleanupOrphanK8SPodEntries(ctx context.Context, _ string, 
 	}
 	res, err := otterizegraphql.ReportActiveCertificateRequesters(ctx, c.graphqlClient, namespacedPodOwners)
 	if err != nil {
-		return fmt.Errorf("failed removing orphan entries: %w", err)
+		return errors.Errorf("failed removing orphan entries: %w", err)
 	}
 	if !res.ReportActiveCertificateRequesters {
-		return fmt.Errorf("failed removing orphan entries")
+		return errors.Errorf("failed removing orphan entries")
 	}
 
 	return nil

--- a/src/operator/controllers/secrets/base.go
+++ b/src/operator/controllers/secrets/base.go
@@ -276,7 +276,7 @@ func (m *K8sSecretsManagerBase[T]) TriggerPodRestarts(ctx context.Context, owner
 		m.eventRecorder.Eventf(&daemonSet, corev1.EventTypeNormal, CertRenewReason, "Successfully restarted DaemonSet after secret '%s' renewal", secret.Name)
 
 	default:
-		return fmt.Errorf("unsupported owner type: %s", kind)
+		return errors.Errorf("unsupported owner type: %s", kind)
 	}
 	return nil
 }

--- a/src/operator/controllers/secrets/manager.go
+++ b/src/operator/controllers/secrets/manager.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"context"
-	"fmt"
 	"github.com/otterize/credentials-operator/src/controllers/metadata"
 	"github.com/otterize/credentials-operator/src/controllers/secrets/types"
 	"github.com/otterize/intents-operator/src/shared/errors"
@@ -103,7 +102,7 @@ func (m *DirectSecretsManager) getCertificateData(ctx context.Context, entryID s
 			ExpiryStr: pemCert.Expiry,
 		}, nil
 	default:
-		return secretstypes.CertificateData{}, fmt.Errorf("failed generating secret data. unsupported cert type %s", certConfig.CertType)
+		return secretstypes.CertificateData{}, errors.Errorf("failed generating secret data. unsupported cert type %s", certConfig.CertType)
 	}
 }
 

--- a/src/operator/controllers/secrets/types/secret_types.go
+++ b/src/operator/controllers/secrets/types/secret_types.go
@@ -2,7 +2,7 @@ package secretstypes
 
 import (
 	"context"
-	"fmt"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
@@ -24,7 +24,7 @@ func StrToCertType(strCertType string) (CertType, error) {
 	case PEMCertType:
 		return PEMCertType, nil
 	default:
-		return "", fmt.Errorf("certificate type: %s is not a valid certificate type. valid types: [jks pem]", strCertType)
+		return "", errors.Errorf("certificate type: %s is not a valid certificate type. valid types: [jks pem]", strCertType)
 	}
 }
 


### PR DESCRIPTION
### Description
Replace usage of `fmt.Errorf` with our internal `errors.Errorf` implementation, to ensure that errors are reported with full stack traces. 
