### PR TITLE
Support the new API versions of Otterize's CRD: `v1` and `v2alpha1`

### DIFF
--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.9.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/cert-manager/cert-manager v1.12.3
-	github.com/otterize/intents-operator/src v0.0.0-20240630171002-84eafa9ee60d
+	github.com/otterize/intents-operator/src v0.0.0-20240702143029-f8b4b220cf3f
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.1
 	github.com/samber/lo v1.33.0
 	github.com/sirupsen/logrus v1.9.0

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -423,8 +423,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/otterize/intents-operator/src v0.0.0-20240630171002-84eafa9ee60d h1:ypysdgdoKXad37zz4kA8Udl+5stNDErcQgR64gn0idk=
-github.com/otterize/intents-operator/src v0.0.0-20240630171002-84eafa9ee60d/go.mod h1:nfX02iyk0wXTWYtW/dYiK+MEXD6ZM84fxXBZy7Jy370=
+github.com/otterize/intents-operator/src v0.0.0-20240702143029-f8b4b220cf3f h1:cID1VbzZ+PfG5Cv2WF5cthtn0Bey1yTFiHZKvIw4d7Y=
+github.com/otterize/intents-operator/src v0.0.0-20240702143029-f8b4b220cf3f/go.mod h1:nfX02iyk0wXTWYtW/dYiK+MEXD6ZM84fxXBZy7Jy370=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -39,7 +39,9 @@ import (
 	"github.com/otterize/credentials-operator/src/controllers/spireclient/svids"
 	"github.com/otterize/credentials-operator/src/controllers/tls_pod"
 	"github.com/otterize/credentials-operator/src/operatorconfig"
+	otterizev1 "github.com/otterize/intents-operator/src/operator/api/v1"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	mutatingwebhookconfiguration "github.com/otterize/intents-operator/src/operator/controllers/mutating_webhook_controller"
 	"github.com/otterize/intents-operator/src/operator/otterizecrds"
 	operatorwebhooks "github.com/otterize/intents-operator/src/operator/webhooks"
@@ -98,6 +100,8 @@ func init() {
 	utilruntime.Must(gcpiamv1.AddToScheme(scheme))
 	utilruntime.Must(gcpk8sv1.AddToScheme(scheme))
 	utilruntime.Must(otterizev1alpha3.AddToScheme(scheme))
+	utilruntime.Must(otterizev1.AddToScheme(scheme))
+	utilruntime.Must(otterizev2alpha1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
### Description

In this pull request, we add support to the new API versions.

### References

https://github.com/otterize/intents-operator/pull/439

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
