### PR TITLE
Fix a bug where pods in a deletion process could cause an error when removing their IAM finalizer

### DIFF
--- a/src/operator/controllers/iam/pods/pods_controller.go
+++ b/src/operator/controllers/iam/pods/pods_controller.go
@@ -125,7 +125,7 @@ func (r *PodReconciler) handlePodCleanup(ctx context.Context, pod corev1.Pod) (c
 
 	updatedPod := pod.DeepCopy()
 	if controllerutil.RemoveFinalizer(updatedPod, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedPod, metadata.DeprecatedIAMRoleFinalizer) {
-		err := r.Patch(ctx, updatedPod, client.MergeFrom(&pod))
+		err := r.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil

--- a/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
+++ b/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
@@ -101,7 +101,7 @@ func (r *ServiceAccountReconciler) handleServiceAccountCleanup(ctx context.Conte
 	if serviceAccount.DeletionTimestamp != nil {
 		updatedServiceAccount := serviceAccount.DeepCopy()
 		if controllerutil.RemoveFinalizer(updatedServiceAccount, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedServiceAccount, metadata.DeprecatedIAMRoleFinalizer) {
-			err := r.Client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
+			err := r.Client.Patch(ctx, updatedServiceAccount, client.StrategicMergeFrom(&serviceAccount))
 			if err != nil {
 				if apierrors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, nil


### PR DESCRIPTION
### Description

Use `StrategicMergeFrom` instead of `MergeFrom` when removing finalizers from pods.  


### References

https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client#StrategicMergeFrom:~:text=func-,StrategicMergeFrom,-%C2%B6
