### PR TITLE
Disabling secret rotation by default and adding relevant flag

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -259,10 +259,10 @@ func main() {
 	if err = podUserAndPasswordReconciler.SetupWithManager(mgr); err != nil {
 		logrus.WithField("controller", "podUserAndPassword").WithError(err).Panic("unable to create controller")
 	}
-	if viper.GetBool(operatorconfig.EnablePasswordRotationKey) {
+	if viper.GetBool(operatorconfig.EnableSecretRotationKey) {
 		go podUserAndPasswordReconciler.RotateSecretsLoop(signalHandlerCtx)
 	}
-	
+
 	// +kubebuilder:scaffold:builder
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		logrus.WithError(err).Panic("unable to set up health check")

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -259,10 +259,11 @@ func main() {
 	if err = podUserAndPasswordReconciler.SetupWithManager(mgr); err != nil {
 		logrus.WithField("controller", "podUserAndPassword").WithError(err).Panic("unable to create controller")
 	}
-	go podUserAndPasswordReconciler.RotateSecretsLoop(signalHandlerCtx)
-
+	if viper.GetBool(operatorconfig.EnablePasswordRotationKey) {
+		go podUserAndPasswordReconciler.RotateSecretsLoop(signalHandlerCtx)
+	}
+	
 	// +kubebuilder:scaffold:builder
-
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		logrus.WithError(err).Panic("unable to set up health check")
 	}

--- a/src/operator/operatorconfig/config.go
+++ b/src/operator/operatorconfig/config.go
@@ -51,6 +51,8 @@ const (
 	EnableLeaderElectionKey                    = "leader-elect"
 	EnableLeaderElectionDefault                = false
 	EnvPrefix                                  = "OTTERIZE"
+	EnablePasswordRotationKey                  = "enabled-password-rotation"
+	EnablePasswordRotationDefault              = false
 	DatabasePasswordRotationIntervalKey        = "database-password-rotation-interval"
 	DatabasePasswordRotationIntervalDefault    = time.Hour * 8
 )
@@ -79,6 +81,7 @@ func init() {
 	viper.SetDefault(CertManagerUseClustierIssuerKey, CertManagerUseClusterIssuerDefault)
 	viper.SetDefault(UseCertManagerApproverKey, UseCertManagerApproverDefault)
 	viper.SetDefault(AWSUseSoftDeleteStrategyKey, AWSUseSoftDeleteStrategyDefault)
+	viper.SetDefault(EnablePasswordRotationKey, EnablePasswordRotationDefault)
 	viper.SetDefault(DebugKey, DebugDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))

--- a/src/operator/operatorconfig/config.go
+++ b/src/operator/operatorconfig/config.go
@@ -51,8 +51,8 @@ const (
 	EnableLeaderElectionKey                    = "leader-elect"
 	EnableLeaderElectionDefault                = false
 	EnvPrefix                                  = "OTTERIZE"
-	EnablePasswordRotationKey                  = "enabled-password-rotation"
-	EnablePasswordRotationDefault              = false
+	EnableSecretRotationKey                    = "enable-secret-rotation"
+	EnableSecretRotationDefault                = false
 	DatabasePasswordRotationIntervalKey        = "database-password-rotation-interval"
 	DatabasePasswordRotationIntervalDefault    = time.Hour * 8
 )
@@ -81,7 +81,7 @@ func init() {
 	viper.SetDefault(CertManagerUseClustierIssuerKey, CertManagerUseClusterIssuerDefault)
 	viper.SetDefault(UseCertManagerApproverKey, UseCertManagerApproverDefault)
 	viper.SetDefault(AWSUseSoftDeleteStrategyKey, AWSUseSoftDeleteStrategyDefault)
-	viper.SetDefault(EnablePasswordRotationKey, EnablePasswordRotationDefault)
+	viper.SetDefault(EnableSecretRotationKey, EnableSecretRotationDefault)
 	viper.SetDefault(DebugKey, DebugDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))


### PR DESCRIPTION
### Description
Secret rotation is now disabled by default and can be enabled via the relevant field in the operator's `values.yaml`. 

### References
[Helm chart PR](https://github.com/otterize/helm-charts/pull/236)