### PR TITLE
Bump intents-operator version to latest main

### DIFF
--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.9.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/cert-manager/cert-manager v1.12.3
-	github.com/otterize/intents-operator/src v0.0.0-20240715131719-550990370c0c
+	github.com/otterize/intents-operator/src v0.0.0-20240728122430-815e69d82f7a
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.1
 	github.com/samber/lo v1.33.0
 	github.com/sirupsen/logrus v1.9.0

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -423,8 +423,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/otterize/intents-operator/src v0.0.0-20240715131719-550990370c0c h1:qLIjbLyUOw6ruB59rrEW7om9qlflJ1eGSnwVvMefJb8=
-github.com/otterize/intents-operator/src v0.0.0-20240715131719-550990370c0c/go.mod h1:R4tfDkJToFDE931Qk7gi47KhXX5WJ3bBYIfskQ1l3Wg=
+github.com/otterize/intents-operator/src v0.0.0-20240728122430-815e69d82f7a h1:96jioV6t6owJWPvkESdwC1rDmpqGL4CGtGZYyrrP4do=
+github.com/otterize/intents-operator/src v0.0.0-20240728122430-815e69d82f7a/go.mod h1:R4tfDkJToFDE931Qk7gi47KhXX5WJ3bBYIfskQ1l3Wg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=


### PR DESCRIPTION
### Description

Bump github.com/otterize/intents-operator/src dependency to latest main version. 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
