### PR TITLE
Avoid attempting to override pod containers when updating labels & annotations

### DIFF
--- a/src/operator/controllers/iam/pods/pods_controller.go
+++ b/src/operator/controllers/iam/pods/pods_controller.go
@@ -86,7 +86,7 @@ func (r *PodReconciler) handlePodUpdate(ctx context.Context, pod corev1.Pod) (ct
 	}
 	if updated {
 		controllerutil.AddFinalizer(updatedPod, r.agent.FinalizerName())
-		err := r.Patch(ctx, updatedPod, client.MergeFrom(&pod))
+		err := r.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
@@ -95,7 +95,7 @@ func (r *PodReconciler) handlePodUpdate(ctx context.Context, pod corev1.Pod) (ct
 		}
 
 		apiutils.AddLabel(updatedServiceAccount, r.agent.ServiceAccountLabel(), metadata.OtterizeServiceAccountHasPodsValue)
-		err = r.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
+		err = r.Patch(ctx, updatedServiceAccount, client.StrategicMergeFrom(&serviceAccount))
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
@@ -125,7 +125,7 @@ func (r *PodReconciler) handlePodCleanup(ctx context.Context, pod corev1.Pod) (c
 
 	updatedPod := pod.DeepCopy()
 	if controllerutil.RemoveFinalizer(updatedPod, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedPod, metadata.DeprecatedIAMRoleFinalizer) {
-		err := r.Patch(ctx, updatedPod, client.MergeFrom(&pod))
+		err := r.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
@@ -169,7 +169,7 @@ func (r *PodReconciler) handleLastPodWithThisSA(ctx context.Context, pod corev1.
 	// Normally we would call the other reconciler, but because this is blocking the removal of a pod finalizer,
 	// we instead update the ServiceAccount and let it do the hard work, so we can remove the pod finalizer ASAP.
 	apiutils.AddLabel(updatedServiceAccount, r.agent.ServiceAccountLabel(), metadata.OtterizeServiceAccountHasNoPodsValue)
-	err = r.Client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
+	err = r.Client.Patch(ctx, updatedServiceAccount, client.StrategicMergeFrom(&serviceAccount))
 	if err != nil {
 		if apierrors.IsConflict(err) {
 			return true, nil

--- a/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
+++ b/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
@@ -74,7 +74,7 @@ func (r *ServiceAccountReconciler) handleServiceAccountUpdate(ctx context.Contex
 	}
 	if updated {
 		controllerutil.AddFinalizer(updatedServiceAccount, r.agent.FinalizerName())
-		err := r.Client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
+		err := r.Client.Patch(ctx, updatedServiceAccount, client.StrategicMergeFrom(&serviceAccount))
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
@@ -101,7 +101,7 @@ func (r *ServiceAccountReconciler) handleServiceAccountCleanup(ctx context.Conte
 	if serviceAccount.DeletionTimestamp != nil {
 		updatedServiceAccount := serviceAccount.DeepCopy()
 		if controllerutil.RemoveFinalizer(updatedServiceAccount, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedServiceAccount, metadata.DeprecatedIAMRoleFinalizer) {
-			err := r.Client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
+			err := r.Client.Patch(ctx, updatedServiceAccount, client.StrategicMergeFrom(&serviceAccount))
 			if err != nil {
 				if apierrors.IsConflict(err) {
 					return ctrl.Result{Requeue: true}, nil

--- a/src/operator/controllers/iam/webhooks/pod_webhook.go
+++ b/src/operator/controllers/iam/webhooks/pod_webhook.go
@@ -69,7 +69,7 @@ func (w *ServiceAccountAnnotatingPodWebhook) handleOnce(ctx context.Context, pod
 
 	if !dryRun {
 		apiutils.AddLabel(updatedServiceAccount, w.agent.ServiceAccountLabel(), metadata.OtterizeServiceAccountHasPodsValue)
-		err = w.client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
+		err = w.client.Patch(ctx, updatedServiceAccount, client.StrategicMergeFrom(&serviceAccount))
 		if err != nil {
 			return corev1.Pod{}, false, "", errors.Errorf("could not patch service account: %w", err)
 		}

--- a/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
+++ b/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
@@ -292,7 +292,7 @@ func (e *Reconciler) rotateSecret(ctx context.Context, secret v1.Secret) (v1.Sec
 	} else {
 		updatedSecret.Annotations[metadata.SecretLastUpdatedTimestampAnnotation] = time.Now().Format(time.RFC3339)
 	}
-	if err := e.client.Patch(ctx, updatedSecret, client.MergeFrom(&secret)); err != nil {
+	if err := e.client.Patch(ctx, updatedSecret, client.StrategicMergeFrom(&secret)); err != nil {
 		return v1.Secret{}, errors.Wrap(err)
 	}
 


### PR DESCRIPTION
### Description
This PR fixes a bug in the operator, in which updating pod labels and annotations sometimes failed due to unexpected changes being detected in the pod's containers. 
This is resolved by using StrategicMergeFrom rather than (plain) MergeFrom, which applies updates as strategic patches rather than complete overrides. 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
