### PR TITLE
Handle issue where DB secret already exists by requeueing and restarting the flow

### DIFF
--- a/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
+++ b/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
@@ -185,6 +185,9 @@ func (e *Reconciler) ensurePodUserAndPasswordSecret(ctx context.Context, pod *v1
 		secret := buildUserAndPasswordCredentialsSecret(secretName, pod.Namespace, username, password)
 		log.WithField("secret", secretName).Debug("Creating new secret with user-password credentials")
 		if err := e.client.Create(ctx, secret); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return ctrl.Result{Requeue: true}, false, "", nil
+			}
 			return ctrl.Result{}, false, "", errors.Wrap(err)
 		}
 		return ctrl.Result{}, true, password, nil


### PR DESCRIPTION
### Description

Before this PR, when a Secret already existed, the operator would report an error and retry. Now, it only retries, as this can happen under normal circumstances.