### PR TITLE
Expose AWS roles anywhere arguments as env vars, so that client containers can use them to obtain temporary security credentials

### DIFF
--- a/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
+++ b/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
@@ -127,6 +127,14 @@ func (a *Agent) OnPodAdmission(ctx context.Context, pod *corev1.Pod, serviceAcco
 				Name:  "AWS_ROLES_ANYWHERE_TRUST_ANCHOR_ARN",
 				Value: a.agent.TrustAnchorArn,
 			},
+			{
+				Name:  "AWS_ROLES_ANYWHERE_PRIVATE_KEY_PATH",
+				Value: "/aws-config/tls.key",
+			},
+			{
+				Name:  "AWS_ROLES_ANYWHERE_CERT_PATH",
+				Value: "/aws-config/tls.crt",
+			},
 		}
 
 		for i := range pod.Spec.Containers {

--- a/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
+++ b/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
@@ -98,16 +98,40 @@ func (a *Agent) OnPodAdmission(ctx context.Context, pod *corev1.Pod, serviceAcco
 			},
 		})
 
-		for i := range pod.Spec.Containers {
-			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
+		extraVolumeMounts := []corev1.VolumeMount{
+			{
 				Name:      "spiffe",
 				MountPath: "/aws-config",
 				ReadOnly:  true,
-			})
-			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, corev1.EnvVar{
+			},
+		}
+
+		extraEnv := []corev1.EnvVar{
+			{
 				Name:  "AWS_SHARED_CREDENTIALS_FILE",
 				Value: "/aws-config/credentials",
-			})
+			},
+			{
+				Name:  "AWS_ROLES_ANYWHERE_ENABLED",
+				Value: "true",
+			},
+			{
+				Name:  "AWS_ROLES_ANYWHERE_ROLE_ARN",
+				Value: *role.Arn,
+			},
+			{
+				Name:  "AWS_ROLES_ANYWHERE_PROFILE_ARN",
+				Value: *profile.ProfileArn,
+			},
+			{
+				Name:  "AWS_ROLES_ANYWHERE_TRUST_ANCHOR_ARN",
+				Value: a.agent.TrustAnchorArn,
+			},
+		}
+
+		for i := range pod.Spec.Containers {
+			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, extraVolumeMounts...)
+			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, extraEnv...)
 		}
 
 	}


### PR DESCRIPTION
### Description
This PR enhances the credentials-operator's support for AWS roles anywhere, by exposing the AWS role, trust profile & trust anchor ARNs as environment variables, as well as the paths to the private key and cert files generated for that role. This should be used by client containers to obtain temporary security credentials, using the AWS signing helper tool, or using temporary credentials generation with https://github.com/aws/rolesanywhere-credential-helper . 

See https://github.com/otterize/intents-operator/blob/main/src/shared/awsagent/rolesanywhere_creds/credentials_provider.go for a usage example. 

### References
https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html