### PR TITLE
Fix NotFound and Forbidden errors happening on AWS EKS pods and SAs during cleanup

### DIFF
--- a/src/operator/controllers/iam/pods/pods_controller.go
+++ b/src/operator/controllers/iam/pods/pods_controller.go
@@ -127,7 +127,9 @@ func (r *PodReconciler) handlePodCleanup(ctx context.Context, pod corev1.Pod) (c
 	if controllerutil.RemoveFinalizer(updatedPod, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedPod, metadata.DeprecatedIAMRoleFinalizer) {
 		err := r.Patch(ctx, updatedPod, client.MergeFrom(&pod))
 		if err != nil {
-			if apierrors.IsConflict(err) {
+			if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
+				// These are all errors that can happen because the pod is already being deleted, requeuing
+				// should solve them all in a classy way
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, errors.Wrap(err)


### PR DESCRIPTION
### Description
This PR fixes AWS API errors NotFound and Forbidden, that may happen on pods & SAs running on EKS, while the operator attempts to cleanup finalizers applied on them. 
These errors can happen because the service account is already being deleted, and re-queueing should solve them all in a clean way. 
