### PR TITLE
Bugfix on DB credentials reconciler: ignore NotFound errors on querying namespaces

### DIFF
--- a/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
+++ b/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
@@ -91,6 +91,9 @@ func (e *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Fix for when the namespace is terminating but pods aren't getting the delete trigger just yet
 	namespace := v1.Namespace{}
 	if err := e.client.Get(ctx, types.NamespacedName{Name: req.Namespace}, &namespace); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 


### PR DESCRIPTION
### Description
This PR fixes a buggy error report in the database credentials reconcile loop, when attempting to reconcile on an already deleted namespace. 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
