### PR TITLE
Fix Kubernetes API 'Forbidden' errors during update, being wrongly reported as errors on the resource

### DIFF
--- a/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
+++ b/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
@@ -75,7 +75,7 @@ func (r *ServiceAccountReconciler) handleServiceAccountUpdate(ctx context.Contex
 	if updated {
 		err := r.Client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
 		if err != nil {
-			if apierrors.IsConflict(err) {
+			if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, errors.Wrap(err)

--- a/src/operator/controllers/iam/webhooks/pod_webhook.go
+++ b/src/operator/controllers/iam/webhooks/pod_webhook.go
@@ -86,7 +86,7 @@ func (w *ServiceAccountAnnotatingPodWebhook) handleWithRetriesOnConflictOrNotFou
 		logger.Debugf("Handling pod (attempt %d out of %d)", attempt+1, maxRetries)
 		outputPod, patched, successMsg, err = w.handleOnce(ctx, *pod.DeepCopy(), dryRun)
 		if err != nil {
-			if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) {
+			if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
 				logger.WithError(err).Errorf("failed to handle pod due to conflict, retrying in 1 second (attempt %d out of %d)", attempt+1, 3)
 				time.Sleep(1 * time.Second)
 				continue

--- a/src/operator/controllers/tls_pod/tls_pod_reconciler.go
+++ b/src/operator/controllers/tls_pod/tls_pod_reconciler.go
@@ -101,7 +101,7 @@ func (r *PodReconciler) updatePodLabel(ctx context.Context, pod *corev1.Pod, lab
 	pod.Labels[labelKey] = labelValue
 
 	if err := r.Update(ctx, pod); err != nil {
-		if apierrors.IsConflict(err) {
+		if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 			// The Pod has been updated since we read it.
 			// Requeue the Pod to try to reconciliate again.
 			return ctrl.Result{Requeue: true}, nil


### PR DESCRIPTION
### Description
This PR fixes an issue with handling Kubernetes API 'Forbidden' errors during update, which are being wrongly reported as errors in the logs and on the Kubernetes resource. These errors are expected during the normal workflow of a reconciler, e.g. when the resource in question is already being deleted. They should be caught and the flow should be requeued (similar to 'Conflict' errors). 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
