### PR TITLE
Use StrategicMergeFrom to update finalizers

### DIFF
--- a/src/operator/controllers/iam/pods/pods_controller.go
+++ b/src/operator/controllers/iam/pods/pods_controller.go
@@ -127,7 +127,7 @@ func (r *PodReconciler) handlePodCleanup(ctx context.Context, pod corev1.Pod) (c
 	if controllerutil.RemoveFinalizer(updatedPod, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedPod, metadata.DeprecatedIAMRoleFinalizer) {
 		err := r.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if err != nil {
-			if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
+			if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) || apierrors.IsInvalid(err) {
 				// These are all errors that can happen because the pod is already being deleted, requeuing
 				// should solve them all in a classy way
 				return ctrl.Result{Requeue: true}, nil

--- a/src/operator/controllers/iam/pods/pods_controller.go
+++ b/src/operator/controllers/iam/pods/pods_controller.go
@@ -125,7 +125,7 @@ func (r *PodReconciler) handlePodCleanup(ctx context.Context, pod corev1.Pod) (c
 
 	updatedPod := pod.DeepCopy()
 	if controllerutil.RemoveFinalizer(updatedPod, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedPod, metadata.DeprecatedIAMRoleFinalizer) {
-		err := r.Patch(ctx, updatedPod, client.MergeFrom(&pod))
+		err := r.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if err != nil {
 			if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 				// These are all errors that can happen because the pod is already being deleted, requeuing


### PR DESCRIPTION
### Description

A possible race condition exists when deleting an object using foregroundDeletion. It is possible when deleting an object with children using foregroundDeletion, for the watcher to have a different knowledge of the finalizer list than the API server that receives the Patch request, i.e. the watcher sees the foregroundDeletion finalizer, but the server that accepts the patch request doesn't so it looks like it was added. Using StrategicMergeFrom creates a proper patch instead of replacing the list, which solves the issue.

Additionally, ignore errors for invalid patches while cleaning up.


### References
Very similar bug: https://github.com/kubernetes/kubernetes/issues/111643

