### PR TITLE
Adding call to error unwrap so we could compare with k8s errors

### DIFF
--- a/src/operator/controllers/iam/webhooks/pod_webhook.go
+++ b/src/operator/controllers/iam/webhooks/pod_webhook.go
@@ -85,8 +85,9 @@ func (w *ServiceAccountAnnotatingPodWebhook) handleWithRetriesOnConflictOrNotFou
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		logger.Debugf("Handling pod (attempt %d out of %d)", attempt+1, maxRetries)
 		outputPod, patched, successMsg, err = w.handleOnce(ctx, *pod.DeepCopy(), dryRun)
+		unwrappedErr := errors.Unwrap(err)
 		if err != nil {
-			if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
+			if k8serrors.IsConflict(unwrappedErr) || k8serrors.IsNotFound(unwrappedErr) || k8serrors.IsForbidden(unwrappedErr) {
 				logger.WithError(err).Errorf("failed to handle pod due to conflict, retrying in 1 second (attempt %d out of %d)", attempt+1, 3)
 				time.Sleep(1 * time.Second)
 				continue


### PR DESCRIPTION
Please see the [contributing guidelines](CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. This template is based on Auth0's excellent template.

### Description
Adding call to error unwrap so we could compare with k8s errors. Beforehand we would compare with a wrapped error which would never "hit" the Kubernetes `IsError()` functions
