### PR TITLE
Cleanup IAM identities on service account deletion

### DIFF
--- a/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
+++ b/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller.go
@@ -35,8 +35,6 @@ func (r *ServiceAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := logrus.WithFields(logrus.Fields{"serviceAccount": req.Name, "namespace": req.Namespace})
-
 	serviceAccount := corev1.ServiceAccount{}
 
 	err := r.Get(ctx, req.NamespacedName, &serviceAccount)
@@ -47,16 +45,8 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 
-	value, ok := serviceAccount.Labels[r.agent.ServiceAccountLabel()]
-	if !ok {
-		logger.Debugf("serviceAccount not labeled with %s, skipping", r.agent.ServiceAccountLabel())
-		return ctrl.Result{}, nil
-	}
-
-	isReferencedByPods := value == metadata.OtterizeServiceAccountHasPodsValue
-
 	// Perform cleanup if the service account is being deleted or no longer referenced by pods
-	if serviceAccount.DeletionTimestamp == nil && isReferencedByPods {
+	if serviceAccount.DeletionTimestamp == nil {
 		return r.handleServiceAccountUpdate(ctx, serviceAccount)
 	}
 

--- a/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller_test.go
+++ b/src/operator/controllers/iam/serviceaccounts/serviceaccount_controller_test.go
@@ -133,35 +133,6 @@ func (s *TestServiceAccountSuite) TestServiceAccountSuite_ServiceAccountTerminat
 	s.Require().Empty(res)
 }
 
-func (s *TestServiceAccountSuite) TestServiceAccountSuite_ServiceAccountServiceAccountLabeledNoPodsDeletesRoleAndDoesntRemoveFinalizer() {
-	req := testutils.GetTestServiceRequestSchema()
-
-	serviceAccount := corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        testServiceAccountName,
-			Namespace:   testNamespace,
-			Annotations: map[string]string{awscredentialsagent.ServiceAccountAWSRoleARNAnnotation: testRoleARN},
-			Labels: map[string]string{
-				mockServiceAccountLabel: metadata.OtterizeServiceAccountHasNoPodsValue,
-			},
-			Finalizers: []string{mockFinalizer},
-		},
-	}
-
-	s.client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.AssignableToTypeOf(&serviceAccount)).DoAndReturn(
-		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *corev1.ServiceAccount, arg3 ...client.GetOption) error {
-			serviceAccount.DeepCopyInto(arg2)
-			return nil
-		},
-	)
-
-	s.mockIAM.EXPECT().OnServiceAccountTermination(context.Background(), gomock.AssignableToTypeOf(&serviceAccount)).Return(nil)
-
-	res, err := s.reconciler.Reconcile(context.Background(), req)
-	s.Require().NoError(err)
-	s.Require().Empty(res)
-}
-
 func (s *TestServiceAccountSuite) TestServiceAccountSuite_ServiceAccountServiceAccountTerminatingButRoleDeletionFailsSoDoesntRemoveFinalizer() {
 	req := testutils.GetTestServiceRequestSchema()
 


### PR DESCRIPTION
### Description

Perform service account cleanup only once it is deleted to avoid race conditions on pod restarts.


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
