### PR TITLE
Bump intents-operator version to include: Update terminology: Rename annotation `intents.otterize.com/service-name` to `intents.otterize.com/workload-name`, retaining support for backward compatibility

### DIFF
--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.9.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/cert-manager/cert-manager v1.12.3
-	github.com/otterize/intents-operator/src v0.0.0-20241212075559-8e21903324c2
+	github.com/otterize/intents-operator/src v0.0.0-20250119123559-c30c1b150ff0
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.1
 	github.com/samber/lo v1.33.0
 	github.com/sirupsen/logrus v1.9.3

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -425,8 +425,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/otterize/intents-operator/src v0.0.0-20241212075559-8e21903324c2 h1:i0XiIW3mN9ARiSP0xt2OQ7+Du4NpxWT2T/Bwx80ALDY=
-github.com/otterize/intents-operator/src v0.0.0-20241212075559-8e21903324c2/go.mod h1:Px9aIWGMrPBMCJdRSDmRpAmn2xcW9z94pSQUzokMYEw=
+github.com/otterize/intents-operator/src v0.0.0-20250119123559-c30c1b150ff0 h1:vO7wjB/HL2Vp6G1ojSSst/yTbNmW2xB2qKNnF4VRW0c=
+github.com/otterize/intents-operator/src v0.0.0-20250119123559-c30c1b150ff0/go.mod h1:Px9aIWGMrPBMCJdRSDmRpAmn2xcW9z94pSQUzokMYEw=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=


### PR DESCRIPTION
### Description

Bump intents-operator version to include: Update terminology: Rename annotation `intents.otterize.com/service-name` to `intents.otterize.com/workload-name`, retaining support for backward compatibility


### References

https://github.com/otterize/intents-operator/pull/542

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
