### PR TITLE
Improve AWS IAM integration debug logging to improve diagnostics for role creation

### DIFF
--- a/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
+++ b/src/operator/controllers/iam/iamcredentialsagents/awscredentialsagent/agent.go
@@ -54,7 +54,7 @@ func (a *Agent) ServiceAccountLabel() string {
 }
 
 func (a *Agent) OnPodAdmission(ctx context.Context, pod *corev1.Pod, serviceAccount *corev1.ServiceAccount, dryRun bool) error {
-	logger := logrus.WithFields(logrus.Fields{"serviceAccount": serviceAccount.Name, "namespace": serviceAccount.Namespace})
+	logger := logrus.WithFields(logrus.Fields{"pod": pod.Name, "serviceAccount": serviceAccount.Name, "namespace": serviceAccount.Namespace})
 
 	roleArn := a.agent.GenerateRoleARN(serviceAccount.Namespace, serviceAccount.Name)
 	apiutils.AddAnnotation(serviceAccount, ServiceAccountAWSRoleARNAnnotation, roleArn)

--- a/src/operator/controllers/iam/pods/pods_controller.go
+++ b/src/operator/controllers/iam/pods/pods_controller.go
@@ -115,14 +115,6 @@ func (r *PodReconciler) handlePodCleanup(ctx context.Context, pod corev1.Pod) (c
 		return ctrl.Result{}, nil
 	}
 
-	requeue, err := r.handleLastPodWithThisSA(ctx, pod)
-	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err)
-	}
-	if requeue {
-		return ctrl.Result{Requeue: true}, nil
-	}
-
 	updatedPod := pod.DeepCopy()
 	if controllerutil.RemoveFinalizer(updatedPod, r.agent.FinalizerName()) || controllerutil.RemoveFinalizer(updatedPod, metadata.DeprecatedIAMRoleFinalizer) {
 		err := r.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
@@ -137,47 +129,4 @@ func (r *PodReconciler) handlePodCleanup(ctx context.Context, pod corev1.Pod) (c
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *PodReconciler) handleLastPodWithThisSA(ctx context.Context, pod corev1.Pod) (requeue bool, err error) {
-	// Find all pods that have the same service account
-	saConsumers, err := apiutils.GetPodServiceAccountConsumers(ctx, r, pod)
-	if err != nil {
-		return false, errors.Wrap(err)
-	}
-
-	// Get only the pods that are IAM consumers - also handles case where label was removed from the pod.
-	iamSAConsumers := lo.Filter(saConsumers, func(filteredPod corev1.Pod, _ int) bool {
-		return controllerutil.ContainsFinalizer(&filteredPod, r.agent.FinalizerName()) || pod.UID == filteredPod.UID
-	})
-
-	// check if this is the last pod linked to this SA.
-	isLastPodWithThisSA := len(iamSAConsumers) == 1 && iamSAConsumers[0].UID == pod.UID
-	if !isLastPodWithThisSA {
-		return false, nil
-	}
-
-	var serviceAccount corev1.ServiceAccount
-	err = r.Get(ctx, types.NamespacedName{Name: pod.Spec.ServiceAccountName, Namespace: pod.Namespace}, &serviceAccount)
-	if err != nil {
-		// service account can be deleted before the pods go down, in which case cleanup has already occurred, so just let the pod terminate.
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, errors.Wrap(err)
-	}
-
-	updatedServiceAccount := serviceAccount.DeepCopy()
-	// Normally we would call the other reconciler, but because this is blocking the removal of a pod finalizer,
-	// we instead update the ServiceAccount and let it do the hard work, so we can remove the pod finalizer ASAP.
-	apiutils.AddLabel(updatedServiceAccount, r.agent.ServiceAccountLabel(), metadata.OtterizeServiceAccountHasNoPodsValue)
-	err = r.Client.Patch(ctx, updatedServiceAccount, client.MergeFrom(&serviceAccount))
-	if err != nil {
-		if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
-			return true, nil
-		}
-		return false, errors.Wrap(err)
-	}
-
-	return false, nil
 }

--- a/src/operator/controllers/iam/pods/pods_controller_test.go
+++ b/src/operator/controllers/iam/pods/pods_controller_test.go
@@ -2,23 +2,18 @@ package pods
 
 import (
 	"context"
-	"errors"
 	mock_iamcredentialsagents "github.com/otterize/credentials-operator/src/controllers/iam/iamcredentialsagents/mocks"
 	"github.com/otterize/credentials-operator/src/controllers/metadata"
 	mock_client "github.com/otterize/credentials-operator/src/mocks/controller-runtime/client"
-	"github.com/otterize/credentials-operator/src/shared/apiutils"
 	"github.com/otterize/credentials-operator/src/shared/testutils"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"testing"
 )
 
@@ -126,7 +121,7 @@ func (s *TestPodsControllerSuite) TestPodTerminatingWithNoFinalizerIsNotAffected
 	s.Require().Empty(res)
 }
 
-func (s *TestPodsControllerSuite) TestLastPodTerminatingButDifferentPodUIDDoesNotLabelServiceAccountAndRemovesFinalizer() {
+func (s *TestPodsControllerSuite) TestLastPodTerminatingWithFinalizerRemovesFinalizer() {
 	req := testutils.GetTestPodRequestSchema()
 
 	serviceAccount := testutils.GetTestServiceSchema()
@@ -142,78 +137,6 @@ func (s *TestPodsControllerSuite) TestLastPodTerminatingButDifferentPodUIDDoesNo
 			return nil
 		},
 	)
-
-	s.client.EXPECT().List(
-		gomock.Any(),
-		gomock.AssignableToTypeOf(&corev1.PodList{}),
-		client.MatchingFields{apiutils.PodServiceAccountIndexField: serviceAccount.Name},
-		gomock.Any(),
-	).DoAndReturn(
-		func(arg0 context.Context, arg1 *corev1.PodList, arg2 ...client.ListOption) error {
-			podList := corev1.PodList{Items: []corev1.Pod{pod}}
-			podList.Items[0].UID += "somestring"
-
-			podList.DeepCopyInto(arg1)
-			return nil
-		},
-	)
-
-	// should not update serviceaccount because UID was different
-	updatedPod := pod.DeepCopy()
-	s.Require().True(controllerutil.RemoveFinalizer(updatedPod, mockFinalizer))
-
-	s.client.EXPECT().Patch(gomock.Any(), updatedPod, gomock.Any())
-
-	res, err := s.reconciler.Reconcile(context.Background(), req)
-	s.Require().NoError(err)
-	s.Require().Empty(res)
-}
-
-func (s *TestPodsControllerSuite) TestLastPodTerminatingWithFinalizerLabelsServiceAccountAndRemovesFinalizer() {
-	req := testutils.GetTestPodRequestSchema()
-
-	serviceAccount := testutils.GetTestServiceSchema()
-	serviceAccount.Labels = map[string]string{mockServiceAccountLabel: metadata.OtterizeServiceAccountHasPodsValue}
-
-	pod := testutils.GetTestPodSchema()
-	pod.DeletionTimestamp = lo.ToPtr(metav1.Now())
-	pod.Finalizers = []string{mockFinalizer}
-
-	s.client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.AssignableToTypeOf(&pod)).DoAndReturn(
-		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *corev1.Pod, arg3 ...client.GetOption) error {
-			pod.DeepCopyInto(arg2)
-			return nil
-		},
-	)
-
-	s.client.EXPECT().List(
-		gomock.Any(),
-		gomock.AssignableToTypeOf(&corev1.PodList{}),
-		client.MatchingFields{apiutils.PodServiceAccountIndexField: serviceAccount.Name},
-		gomock.Any(),
-	).DoAndReturn(
-		func(arg0 context.Context, arg1 *corev1.PodList, arg2 ...client.ListOption) error {
-			podList := corev1.PodList{Items: []corev1.Pod{pod}}
-
-			podList.DeepCopyInto(arg1)
-			return nil
-		},
-	)
-
-	s.client.EXPECT().Get(gomock.Any(), types.NamespacedName{
-		Namespace: serviceAccount.Namespace,
-		Name:      serviceAccount.Name,
-	}, gomock.AssignableToTypeOf(&serviceAccount)).DoAndReturn(
-		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *corev1.ServiceAccount, arg3 ...client.GetOption) error {
-			serviceAccount.DeepCopyInto(arg2)
-			return nil
-		},
-	)
-
-	updatedServiceAccount := serviceAccount.DeepCopy()
-	updatedServiceAccount.Labels = map[string]string{mockServiceAccountLabel: metadata.OtterizeServiceAccountHasNoPodsValue}
-
-	s.client.EXPECT().Patch(gomock.Any(), updatedServiceAccount, gomock.Any())
 
 	updatedPod := pod.DeepCopy()
 	s.Require().True(controllerutil.RemoveFinalizer(updatedPod, mockFinalizer))
@@ -223,148 +146,6 @@ func (s *TestPodsControllerSuite) TestLastPodTerminatingWithFinalizerLabelsServi
 	res, err := s.reconciler.Reconcile(context.Background(), req)
 	s.Require().NoError(err)
 	s.Require().Empty(res)
-}
-
-func (s *TestPodsControllerSuite) TestNonLastPodTerminatingDoesNotLabelServiceAccountAndRemovesFinalizer() {
-	req := testutils.GetTestPodRequestSchema()
-
-	serviceAccount := testutils.GetTestServiceSchema()
-	serviceAccount.Labels = map[string]string{mockServiceAccountLabel: metadata.OtterizeServiceAccountHasPodsValue}
-
-	pod := testutils.GetTestPodSchema()
-	pod.DeletionTimestamp = lo.ToPtr(metav1.Now())
-	pod.Finalizers = []string{mockFinalizer}
-
-	s.client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.AssignableToTypeOf(&pod)).DoAndReturn(
-		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *corev1.Pod, arg3 ...client.GetOption) error {
-			pod.DeepCopyInto(arg2)
-			return nil
-		},
-	)
-
-	s.client.EXPECT().List(
-		gomock.Any(),
-		gomock.AssignableToTypeOf(&corev1.PodList{}),
-		client.MatchingFields{apiutils.PodServiceAccountIndexField: serviceAccount.Name},
-		gomock.Any(),
-	).DoAndReturn(
-		func(arg0 context.Context, arg1 *corev1.PodList, arg2 ...client.ListOption) error {
-			pod2 := testutils.GetTestPodSchema()
-			pod2.UID += "2"
-			pod2.Name += "2"
-			pod2.Finalizers = []string{mockFinalizer}
-
-			podList := corev1.PodList{Items: []corev1.Pod{pod, pod2}}
-			podList.DeepCopyInto(arg1)
-			return nil
-		},
-	)
-
-	// should not update serviceaccount because it's not the last pod
-	updatedPod := pod.DeepCopy()
-	s.Require().True(controllerutil.RemoveFinalizer(updatedPod, mockFinalizer))
-
-	s.client.EXPECT().Patch(gomock.Any(), updatedPod, gomock.Any())
-
-	res, err := s.reconciler.Reconcile(context.Background(), req)
-	s.Require().NoError(err)
-	s.Require().Empty(res)
-}
-
-func (s *TestPodsControllerSuite) TestLastPodTerminatingWithFinalizerServiceAccountGoneAndRemovesFinalizerAnyway() {
-	req := testutils.GetTestPodRequestSchema()
-
-	serviceAccount := testutils.GetTestServiceSchema()
-	serviceAccount.Labels = map[string]string{mockServiceAccountLabel: metadata.OtterizeServiceAccountHasPodsValue}
-
-	pod := testutils.GetTestPodSchema()
-	pod.DeletionTimestamp = lo.ToPtr(metav1.Now())
-	pod.Finalizers = []string{mockFinalizer}
-
-	s.client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.AssignableToTypeOf(&pod)).DoAndReturn(
-		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *corev1.Pod, arg3 ...client.GetOption) error {
-			pod.DeepCopyInto(arg2)
-			return nil
-		},
-	)
-
-	s.client.EXPECT().List(
-		gomock.Any(),
-		gomock.AssignableToTypeOf(&corev1.PodList{}),
-		client.MatchingFields{apiutils.PodServiceAccountIndexField: serviceAccount.Name},
-		gomock.Any(),
-	).DoAndReturn(
-		func(arg0 context.Context, arg1 *corev1.PodList, arg2 ...client.ListOption) error {
-			podList := corev1.PodList{Items: []corev1.Pod{pod}}
-			podList.DeepCopyInto(arg1)
-			return nil
-		},
-	)
-
-	s.client.EXPECT().Get(gomock.Any(), types.NamespacedName{
-		Namespace: serviceAccount.Namespace,
-		Name:      serviceAccount.Name,
-	}, gomock.AssignableToTypeOf(&serviceAccount)).Return(k8serrors.NewNotFound(schema.GroupResource{}, serviceAccount.Name))
-
-	updatedPod := pod.DeepCopy()
-	s.Require().True(controllerutil.RemoveFinalizer(updatedPod, mockFinalizer))
-
-	s.client.EXPECT().Patch(gomock.Any(), updatedPod, gomock.Any())
-
-	res, err := s.reconciler.Reconcile(context.Background(), req)
-	s.Require().NoError(err)
-	s.Require().Empty(res)
-}
-
-func (s *TestPodsControllerSuite) TestLastPodTerminatingWithFinalizerLabelsServiceAccountButIsConflictSoRequeues() {
-	req := testutils.GetTestPodRequestSchema()
-
-	serviceAccount := testutils.GetTestServiceSchema()
-	serviceAccount.Labels = map[string]string{mockServiceAccountLabel: metadata.OtterizeServiceAccountHasPodsValue}
-
-	pod := testutils.GetTestPodSchema()
-	pod.DeletionTimestamp = lo.ToPtr(metav1.Now())
-	pod.Finalizers = []string{mockFinalizer}
-
-	s.client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.AssignableToTypeOf(&pod)).DoAndReturn(
-		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *corev1.Pod, arg3 ...client.GetOption) error {
-			pod.DeepCopyInto(arg2)
-			return nil
-		},
-	)
-
-	s.client.EXPECT().List(
-		gomock.Any(),
-		gomock.AssignableToTypeOf(&corev1.PodList{}),
-		client.MatchingFields{apiutils.PodServiceAccountIndexField: serviceAccount.Name},
-		gomock.Any(),
-	).DoAndReturn(
-		func(arg0 context.Context, arg1 *corev1.PodList, arg2 ...client.ListOption) error {
-			podList := corev1.PodList{Items: []corev1.Pod{pod}}
-
-			podList.DeepCopyInto(arg1)
-			return nil
-		},
-	)
-
-	s.client.EXPECT().Get(gomock.Any(), types.NamespacedName{
-		Namespace: serviceAccount.Namespace,
-		Name:      serviceAccount.Name,
-	}, gomock.AssignableToTypeOf(&serviceAccount)).DoAndReturn(
-		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *corev1.ServiceAccount, arg3 ...client.GetOption) error {
-			serviceAccount.DeepCopyInto(arg2)
-			return nil
-		},
-	)
-
-	updatedServiceAccount := serviceAccount.DeepCopy()
-	updatedServiceAccount.Labels = map[string]string{mockServiceAccountLabel: metadata.OtterizeServiceAccountHasNoPodsValue}
-
-	s.client.EXPECT().Patch(gomock.Any(), updatedServiceAccount, gomock.Any()).Return(k8serrors.NewConflict(schema.GroupResource{}, serviceAccount.Name, errors.New("conflict")))
-
-	res, err := s.reconciler.Reconcile(context.Background(), req)
-	s.Require().NoError(err)
-	s.Require().Equal(reconcile.Result{Requeue: true}, res)
 }
 
 func TestRunPodsControllerSuite(t *testing.T) {

--- a/src/operator/controllers/metadata/labels.go
+++ b/src/operator/controllers/metadata/labels.go
@@ -11,6 +11,5 @@ const (
 	// This is used to detect which secrets are managed by this operator.
 	SecretTypeLabel = "credentials-operator.otterize.com/secret-type"
 
-	OtterizeServiceAccountHasPodsValue   = "true"
-	OtterizeServiceAccountHasNoPodsValue = "no-pods"
+	OtterizeServiceAccountHasPodsValue = "true"
 )

--- a/src/operator/shared/apiutils/pods.go
+++ b/src/operator/shared/apiutils/pods.go
@@ -3,7 +3,6 @@ package apiutils
 import (
 	"context"
 	"github.com/otterize/intents-operator/src/shared/errors"
-	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,26 +28,6 @@ func InitPodServiceAccountIndexField(mgr ctrl.Manager) error {
 	}
 
 	return nil
-}
-
-func GetPodServiceAccountConsumers(ctx context.Context, c client.Client, pod corev1.Pod) ([]corev1.Pod, error) {
-	pods := corev1.PodList{}
-	err := c.List(ctx, &pods,
-		client.MatchingFields{PodServiceAccountIndexField: pod.Spec.ServiceAccountName},
-		&client.ListOptions{Namespace: pod.Namespace},
-	)
-	if err != nil {
-		return nil, errors.Wrap(err)
-	}
-
-	thisPodAndNonTerminatingPods := lo.Filter(pods.Items, func(filteredPod corev1.Pod, _ int) bool {
-		if pod.UID == filteredPod.UID || filteredPod.DeletionTimestamp == nil {
-			return true
-		}
-		return false
-	})
-
-	return thisPodAndNonTerminatingPods, nil
 }
 
 func AddLabel(o client.Object, key, value string) {


### PR DESCRIPTION
### Description
- Improve AWS IAM integration debug logging to ease troubleshooting around unexpected role creation: add debug- or info-level logging around IAM-related updates of pods and service accounts
- Remove redundant labeling of service account on last pod terminating in AWS IAM integration, which is no longer used and is just a cause for potential conflicts. 

### References
https://github.com/otterize/credentials-operator/pull/171

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
