### PR TITLE
Support new API version for ClientIntents: v2beta1

### DIFF
--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.9.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/cert-manager/cert-manager v1.12.3
-	github.com/otterize/intents-operator/src v0.0.0-20250123172621-3f81e8288721
+	github.com/otterize/intents-operator/src v0.0.0-20250126101538-94c76a77e656
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.1
 	github.com/samber/lo v1.47.0
 	github.com/sirupsen/logrus v1.9.3

--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.9.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/cert-manager/cert-manager v1.12.3
-	github.com/otterize/intents-operator/src v0.0.0-20250122082157-56ba6855b221
+	github.com/otterize/intents-operator/src v0.0.0-20250123172621-3f81e8288721
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.1
 	github.com/samber/lo v1.47.0
 	github.com/sirupsen/logrus v1.9.3

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -425,8 +425,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/otterize/intents-operator/src v0.0.0-20250122082157-56ba6855b221 h1:y2Htd/Po2VQGtDRxeT8PpD9zgZReQeRzHcindVq7N9s=
-github.com/otterize/intents-operator/src v0.0.0-20250122082157-56ba6855b221/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
+github.com/otterize/intents-operator/src v0.0.0-20250123172621-3f81e8288721 h1:mAb99ZOCed1lYJYuaqU9yQBz2ye5kDzJyLMxVkn9YhU=
+github.com/otterize/intents-operator/src v0.0.0-20250123172621-3f81e8288721/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -425,8 +425,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/otterize/intents-operator/src v0.0.0-20250123172621-3f81e8288721 h1:mAb99ZOCed1lYJYuaqU9yQBz2ye5kDzJyLMxVkn9YhU=
-github.com/otterize/intents-operator/src v0.0.0-20250123172621-3f81e8288721/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
+github.com/otterize/intents-operator/src v0.0.0-20250126101538-94c76a77e656 h1:zw/O3/ak5MVSZQj2lZT7lZBlkul6/SoSDlNIcYqXaFo=
+github.com/otterize/intents-operator/src v0.0.0-20250126101538-94c76a77e656/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -42,6 +42,7 @@ import (
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	otterizev1beta1 "github.com/otterize/intents-operator/src/operator/api/v1beta1"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
+	otterizev2beta1 "github.com/otterize/intents-operator/src/operator/api/v2beta1"
 	mutatingwebhookconfiguration "github.com/otterize/intents-operator/src/operator/controllers/mutating_webhook_controller"
 	"github.com/otterize/intents-operator/src/operator/otterizecrds"
 	operatorwebhooks "github.com/otterize/intents-operator/src/operator/webhooks"
@@ -101,6 +102,7 @@ func init() {
 	utilruntime.Must(gcpk8sv1.AddToScheme(scheme))
 	utilruntime.Must(otterizev1alpha3.AddToScheme(scheme))
 	utilruntime.Must(otterizev1beta1.AddToScheme(scheme))
+	utilruntime.Must(otterizev2beta1.AddToScheme(scheme))
 	utilruntime.Must(otterizev2alpha1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
### Description
We have revamped the format for ClientIntents to make them easier to understand and make it possible to generate more restrictive policies by default. [Read more on the docs >>](https://docs.otterize.com/reference/ClientIntents%20CRD/migrateToV2)

The two primary changes is that the word `service` is no longer used, except to mean a Kubernetes Service; before, it could mean an Otterize Service or a Kubernetes Service, which was confusing. Instead, we now use `workload` . `calls` have also been renamed `targets` , and many smaller changes to the structure to improve

What happens to your existing ClientIntents? Don’t worry, the change is backwards compatible, and nothing changes unless you explicitly upgrade. If you’re a customer, we’ll reach out to explain and plan together. If you’re using the open source, upgrading to the next **major** version of the `otterize-kubernetes` Helm chart, `vX.X.X` will make ClientIntents v2 the default. You can still continue applying ClientIntents with apiVersion `v1alpha3`, and they will be converted by the Intents Operator to `v2beta1`. 

### References

https://github.com/otterize/intents-operator/pull/552
https://github.com/otterize/credentials-operator/pull/179
https://github.com/otterize/network-mapper/pull/267
https://github.com/otterize/helm-charts/pull/278

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
