### PR TITLE
Fix credentials-operator webhook malfunctioning due to wrong self-signed certificate hostname

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -241,7 +241,7 @@ func main() {
 		}
 		if !ok || err != nil {
 			certBundleNew, err :=
-				operatorwebhooks.GenerateSelfSignedCertificate("intents-operator-webhook-service", podNamespace)
+				operatorwebhooks.GenerateSelfSignedCertificate("credentials-operator-webhook-service", podNamespace)
 			if err != nil {
 				logrus.WithError(err).Panic("unable to create self signed certs for webhook")
 			}


### PR DESCRIPTION
### Description
Fix credentials-operator webhook malfunctioning due to wrong self-signed certificate hostname

### References
Follow-up on https://github.com/otterize/credentials-operator/pull/180

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
