### PR TITLE
Fix issue in webhook cert persistency where credentials-operator secret name was wrong due to use of configuration

### DIFF
--- a/src/operator/go.mod
+++ b/src/operator/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.9.0
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/cert-manager/cert-manager v1.12.3
-	github.com/otterize/intents-operator/src v0.0.0-20250216195128-92a5a99accfd
+	github.com/otterize/intents-operator/src v0.0.0-20250218114932-612fa0f71764
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.4.1
 	github.com/samber/lo v1.47.0
 	github.com/sirupsen/logrus v1.9.3

--- a/src/operator/go.sum
+++ b/src/operator/go.sum
@@ -425,8 +425,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/otterize/intents-operator/src v0.0.0-20250216195128-92a5a99accfd h1:wPYS7OzDOh72rxNBkQnSrOfSL9z7fAVSahvvyQ5hwdQ=
-github.com/otterize/intents-operator/src v0.0.0-20250216195128-92a5a99accfd/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
+github.com/otterize/intents-operator/src v0.0.0-20250218114932-612fa0f71764 h1:YlyjoUQPbe2GU4JtKHpt9p/v8F5lVb5WHdzWtiUrznw=
+github.com/otterize/intents-operator/src v0.0.0-20250218114932-612fa0f71764/go.mod h1:lHQJZ1DrMdxF7rtoi70nafyYPYeqD59QVZ+oCfYysoU=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd h1:7Sb95VrtAPb9m2ewtqLnX1oeKQy03dt7yr6F/hP7Htg=
 github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd/go.mod h1:RXvgymN8MxiELFkmGHzJ23KJU2ObVsNsNSM80/HO8qQ=
 github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f h1:gv92189CW53A+Y0UQ550zr6RfCBYqvYJ8oq6Jll1YqQ=

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -231,7 +231,7 @@ func main() {
 	// setup webhook
 	if viper.GetBool(operatorconfig.SelfSignedCertKey) {
 		logrus.Infoln("Creating self signing certs")
-		secretName := viper.GetString(operatorconfig.WebhookCertSecretNameKey)
+		secretName := "credentials-operator-webhook-cert"
 		certBundle, ok, err := operatorwebhooks.ReadCertBundleFromSecret(signalHandlerCtx, directClient, secretName, podNamespace)
 		if err != nil {
 			logrus.WithError(err).Warn("unable to read existing certs from secret, generating new ones")

--- a/src/operator/operatorconfig/config.go
+++ b/src/operator/operatorconfig/config.go
@@ -57,8 +57,6 @@ const (
 	EnableSecretRotationDefault                = false
 	DatabasePasswordRotationIntervalKey        = "database-password-rotation-interval"
 	DatabasePasswordRotationIntervalDefault    = time.Hour * 8
-	WebhookCertSecretNameKey                   = "webhook-cert-secret-name"
-	WebhookCertSecretNameDefault               = "credentials-operator-webhook-cert"
 )
 
 const (
@@ -88,7 +86,6 @@ func init() {
 	viper.SetDefault(AWSUseSoftDeleteStrategyKey, AWSUseSoftDeleteStrategyDefault)
 	viper.SetDefault(EnableSecretRotationKey, EnableSecretRotationDefault)
 	viper.SetDefault(DebugKey, DebugDefault)
-	viper.SetDefault(WebhookCertSecretNameKey, WebhookCertSecretNameDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()


### PR DESCRIPTION
### Description
Fix issue in webhook cert persistency using secrets, where the credentials-operator secret name was wrong due to use of configuration. Instead, use fixed secret names.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
