### PR TITLE
Fixed bug where reconcile loop could occur when user provides an invalid (non-RFC1123) secret name

### DIFF
--- a/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
+++ b/src/operator/controllers/poduserpassword/db_credentials_pod_reconciler.go
@@ -128,8 +128,8 @@ func (e *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	logrus.Debug("Ensuring user-password credentials secrets for pod")
 	if secretNameErrors := validation.IsDNS1123Subdomain(secretName); len(secretNameErrors) > 0 {
 		secretNameErrorsString := strings.Join(secretNameErrors, ", ")
-		logrus.WithFields(logrus.Fields{"pod": pod.Name, "namespace": pod.Namespace, "secretName": secretName}).
-			Warningf("Invalid secret name: %s", secretNameErrorsString)
+		logrus.WithFields(logrus.Fields{"pod": pod.Name, "namespace": pod.Namespace, "secretName": secretName, "errors": secretNameErrors}).
+			Warningf("Invalid secret name")
 		e.recorder.Eventf(&pod, v1.EventTypeWarning, ReasonEnsuringPodUserAndPasswordFailed, "Invalid secret name %s: %s", secretName, secretNameErrorsString)
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
### Description

Validate the provided secret name before trying to create it. If it is invalid, record an event and a warning log and finish reconciliation.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
